### PR TITLE
Update for use of higher Hashing Algorithms for key Hash

### DIFF
--- a/crypto/src/bcpg/ArmoredOutputStream.cs
+++ b/crypto/src/bcpg/ArmoredOutputStream.cs
@@ -313,18 +313,57 @@ namespace Org.BouncyCastle.Bcpg
 			}
         }
 
-		private void WriteHeaderEntry(
-			string	name,
-			string	v)
+        protected override void Dispose(bool disposing)
+        {
+            try
+            {
+                if (type != null)
+                {
+                    if (bufPtr > 0)
+                    {
+                        Encode(outStream, buf, bufPtr);
+                    }
+
+                    DoWrite(nl + '=');
+
+                    int crcV = crc.Value;
+
+                    buf[0] = ((crcV >> 16) & 0xff);
+                    buf[1] = ((crcV >> 8) & 0xff);
+                    buf[2] = (crcV & 0xff);
+
+                    Encode(outStream, buf, 3);
+
+                    DoWrite(nl);
+                    DoWrite(footerStart);
+                    DoWrite(type);
+                    DoWrite(footerTail);
+                    DoWrite(nl);
+
+                    outStream.Flush();
+
+                    type = null;
+                    start = true;
+                }
+            }
+            finally
+            {
+                base.Dispose(disposing);
+            }
+        }
+
+        private void WriteHeaderEntry(
+            string name,
+            string v)
         {
             DoWrite(name + ": " + v + nl);
         }
 
-		private void DoWrite(
-			string s)
+        private void DoWrite(
+            string s)
         {
             byte[] bs = Strings.ToAsciiByteArray(s);
-			outStream.Write(bs, 0, bs.Length);
+            outStream.Write(bs, 0, bs.Length);
         }
     }
 }

--- a/crypto/src/openpgp/PgpKeyRingGenerator.cs
+++ b/crypto/src/openpgp/PgpKeyRingGenerator.cs
@@ -15,6 +15,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
         private IList					    keys = Platform.CreateArrayList();
         private string                      id;
         private SymmetricKeyAlgorithmTag	encAlgorithm;
+        private HashAlgorithmTag            hashAlgorithm;
         private int                         certificationLevel;
         private char[]                      passPhrase;
 		private bool						useSha1;
@@ -84,12 +85,62 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
 			keys.Add(new PgpSecretKey(certificationLevel, masterKey, id, encAlgorithm, passPhrase, useSha1, hashedPackets, unhashedPackets, rand));
         }
 
+        /// <summary>
+        /// Create a new key ring generator.
+        /// </summary>
+        /// <param name="certificationLevel">The certification level for keys on this ring.</param>
+        /// <param name="masterKey">The master key pair.</param>
+        /// <param name="id">The id to be associated with the ring.</param>
+        /// <param name="encAlgorithm">The algorithm to be used to protect secret keys.</param>
+        /// <param name="hashAlgorithm">The hash algorithm.</param>
+        /// <param name="passPhrase">The passPhrase to be used to protect secret keys.</param>
+        /// <param name="useSha1">Checksum the secret keys with SHA1 rather than the older 16 bit checksum.</param>
+        /// <param name="hashedPackets">Packets to be included in the certification hash.</param>
+        /// <param name="unhashedPackets">Packets to be attached unhashed to the certification.</param>
+        /// <param name="rand">input secured random.</param>
+        public PgpKeyRingGenerator(
+            int                         certificationLevel,
+            PgpKeyPair                  masterKey,
+            string                      id,
+            SymmetricKeyAlgorithmTag    encAlgorithm,
+            HashAlgorithmTag            hashAlgorithm,
+            char[]                      passPhrase,
+            bool                        useSha1,
+            PgpSignatureSubpacketVector hashedPackets,
+            PgpSignatureSubpacketVector unhashedPackets,
+            SecureRandom                rand)
+        {
+            this.certificationLevel = certificationLevel;
+            this.masterKey = masterKey;
+            this.id = id;
+            this.encAlgorithm = encAlgorithm;
+            this.passPhrase = passPhrase;
+            this.useSha1 = useSha1;
+            this.hashedPacketVector = hashedPackets;
+            this.unhashedPacketVector = unhashedPackets;
+            this.rand = rand;
+            this.hashAlgorithm = hashAlgorithm;
+
+            keys.Add(new PgpSecretKey(certificationLevel, masterKey, id, encAlgorithm, hashAlgorithm, passPhrase, useSha1, hashedPackets, unhashedPackets, rand));
+        }
+
 		/// <summary>Add a subkey to the key ring to be generated with default certification.</summary>
         public void AddSubKey(
             PgpKeyPair keyPair)
         {
 			AddSubKey(keyPair, this.hashedPacketVector, this.unhashedPacketVector);
 		}
+
+
+        /// <summary>
+        /// Add a subkey to the key ring to be generated with default certification.
+        /// </summary>
+        /// <param name="keyPair">The key pair.</param>
+        /// <param name="hashAlgorithm">The hash algorithm.</param>
+        public void AddSubKey(PgpKeyPair keyPair, HashAlgorithmTag hashAlgorithm)
+        {
+            this.AddSubKey(keyPair, this.hashedPacketVector, this.unhashedPacketVector, hashAlgorithm);
+        }
 
 		/// <summary>
 		/// Add a subkey with specific hashed and unhashed packets associated with it and
@@ -132,6 +183,50 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
                 throw new PgpException("exception adding subkey: ", e);
             }
         }
+
+        /// <summary>
+        /// Add a subkey with specific hashed and unhashed packets associated with it and
+        /// default certification.
+        /// </summary>
+        /// <param name="keyPair">Public/private key pair.</param>
+        /// <param name="hashedPackets">Hashed packet values to be included in certification.</param>
+        /// <param name="unhashedPackets">Unhashed packets values to be included in certification.</param>
+        /// <param name="hashAlgorithm">The hash algorithm.</param>
+        /// <exception cref="Org.BouncyCastle.Bcpg.OpenPgp.PgpException">exception adding subkey: </exception>
+        /// <exception cref="PgpException"></exception>
+        public void AddSubKey(
+            PgpKeyPair keyPair,
+            PgpSignatureSubpacketVector hashedPackets,
+            PgpSignatureSubpacketVector unhashedPackets,
+            HashAlgorithmTag hashAlgorithm)
+        {
+            try
+            {
+                var sGen = new PgpSignatureGenerator(masterKey.PublicKey.Algorithm, hashAlgorithm);
+
+                //
+                // Generate the certification
+                //
+                sGen.InitSign(PgpSignature.SubkeyBinding, masterKey.PrivateKey);
+
+                sGen.SetHashedSubpackets(hashedPackets);
+                sGen.SetUnhashedSubpackets(unhashedPackets);
+
+                IList subSigs = Platform.CreateArrayList();
+                subSigs.Add(sGen.GenerateCertification(masterKey.PublicKey, keyPair.PublicKey));
+
+                keys.Add(new PgpSecretKey(keyPair.PrivateKey, new PgpPublicKey(keyPair.PublicKey, null, subSigs), encAlgorithm, passPhrase, useSha1, rand));
+            }
+            catch (PgpException)
+            {
+                throw;
+            }
+            catch (Exception e)
+            {
+                throw new PgpException("exception adding subkey: ", e);
+            }
+        }
+
 
 		/// <summary>Return the secret key ring.</summary>
         public PgpSecretKeyRing GenerateSecretKeyRing()

--- a/crypto/src/openpgp/PgpPublicKeyRing.cs
+++ b/crypto/src/openpgp/PgpPublicKeyRing.cs
@@ -169,6 +169,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
             PgpPublicKeyRing	pubRing,
             PgpPublicKey		pubKey)
         {
+
             IList keys = Platform.CreateArrayList(pubRing.keys);
             bool found = false;
 

--- a/crypto/src/openpgp/PgpSecretKey.cs
+++ b/crypto/src/openpgp/PgpSecretKey.cs
@@ -158,6 +158,21 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
         {
         }
 
+        public PgpSecretKey(
+            int                         certificationLevel,
+            PgpKeyPair                  keyPair,
+            string                      id,
+            SymmetricKeyAlgorithmTag    encAlgorithm,
+            HashAlgorithmTag            hashAlgorithm,
+            char[]                      passPhrase,
+            bool                        useSha1,
+            PgpSignatureSubpacketVector hashedPackets,
+            PgpSignatureSubpacketVector unhashedPackets,
+            SecureRandom                rand)
+            : this(keyPair.PrivateKey, CertifiedPublicKey(certificationLevel, keyPair, id, hashedPackets, unhashedPackets, hashAlgorithm), encAlgorithm, passPhrase, useSha1, rand, true)
+        {
+        }
+
         private static PgpPublicKey CertifiedPublicKey(
             int							certificationLevel,
             PgpKeyPair					keyPair,
@@ -169,6 +184,44 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
             try
             {
                 sGen = new PgpSignatureGenerator(keyPair.PublicKey.Algorithm, HashAlgorithmTag.Sha1);
+            }
+            catch (Exception e)
+            {
+                throw new PgpException("Creating signature generator: " + e.Message, e);
+            }
+
+            //
+            // Generate the certification
+            //
+            sGen.InitSign(certificationLevel, keyPair.PrivateKey);
+
+            sGen.SetHashedSubpackets(hashedPackets);
+            sGen.SetUnhashedSubpackets(unhashedPackets);
+
+            try
+            {
+                PgpSignature certification = sGen.GenerateCertification(id, keyPair.PublicKey);
+                return PgpPublicKey.AddCertification(keyPair.PublicKey, id, certification);
+            }
+            catch (Exception e)
+            {
+                throw new PgpException("Exception doing certification: " + e.Message, e);
+            }
+        }
+
+
+        private static PgpPublicKey CertifiedPublicKey(
+            int certificationLevel,
+            PgpKeyPair keyPair,
+            string id,
+            PgpSignatureSubpacketVector hashedPackets,
+            PgpSignatureSubpacketVector unhashedPackets,
+            HashAlgorithmTag hashAlgorithm)
+        {
+            PgpSignatureGenerator sGen;
+            try
+            {
+                sGen = new PgpSignatureGenerator(keyPair.PublicKey.Algorithm, hashAlgorithm);
             }
             catch (Exception e)
             {
@@ -585,6 +638,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
             SymmetricKeyAlgorithmTag	newEncAlgorithm,
             SecureRandom				rand)
         {
+
             if (key.IsPrivateKeyEmpty)
                 throw new PgpException("no private key in this SecretKey - public key present only.");
 


### PR DESCRIPTION
Currently it supports only the use of SHA1. The latest changes in RFC 4880 in section 13.6 for DSA http://tools.ietf.org/html/rfc4880#section-13.6 if a value for DSA higher than 1024 us used SHA1 is no longer valid this will also affect RFC 6637 where it would be SHA 256. This changes should allow for use of a higher Hashing algorithm for hashing.  