### PR TITLE
Permit Org.BouncyCastle.Crypto.Generators.ECKeyPairGenerator to save cur...

### DIFF
--- a/crypto/src/asn1/cms/EnvelopedData.cs
+++ b/crypto/src/asn1/cms/EnvelopedData.cs
@@ -94,7 +94,7 @@ namespace Org.BouncyCastle.Asn1.Cms
                 return (EnvelopedData)obj;
             if (obj == null)
                 return null;
-            return new EnvelopedData(Asn1Sequence.GetInstance(obj));
+            return EnvelopedData.GetInstance(Asn1Sequence.GetInstance(obj));
         }
 
         public DerInteger Version

--- a/crypto/src/asn1/cms/IssuerAndSerialNumber.cs
+++ b/crypto/src/asn1/cms/IssuerAndSerialNumber.cs
@@ -19,7 +19,7 @@ namespace Org.BouncyCastle.Asn1.Cms
             IssuerAndSerialNumber existing = obj as IssuerAndSerialNumber;
             if (existing != null)
                 return existing;
-            return new IssuerAndSerialNumber(Asn1Sequence.GetInstance(obj));
+            return IssuerAndSerialNumber.GetInstance(Asn1Sequence.GetInstance(obj));
         }
 
         [Obsolete("Use GetInstance() instead")]

--- a/crypto/src/asn1/cms/OtherRecipientInfo.cs
+++ b/crypto/src/asn1/cms/OtherRecipientInfo.cs
@@ -54,7 +54,7 @@ namespace Org.BouncyCastle.Asn1.Cms
             OtherRecipientInfo existing = obj as OtherRecipientInfo;
             if (existing != null)
                 return existing;
-            return new OtherRecipientInfo(Asn1Sequence.GetInstance(obj));
+            return OtherRecipientInfo.GetInstance(Asn1Sequence.GetInstance(obj));
         }
 
         public virtual DerObjectIdentifier OriType

--- a/crypto/src/asn1/cms/SignerInfo.cs
+++ b/crypto/src/asn1/cms/SignerInfo.cs
@@ -24,7 +24,7 @@ namespace Org.BouncyCastle.Asn1.Cms
                 return (SignerInfo) obj;
 
             if (obj is Asn1Sequence)
-                return new SignerInfo((Asn1Sequence) obj);
+                return SignerInfo.GetInstance(Asn1Sequence.GetInstance(obj));
 
             throw new ArgumentException("Unknown object in factory: " + obj.GetType().FullName, "obj");
         }

--- a/crypto/src/asn1/pkcs/PBES2Parameters.cs
+++ b/crypto/src/asn1/pkcs/PBES2Parameters.cs
@@ -15,7 +15,7 @@ namespace Org.BouncyCastle.Asn1.Pkcs
             PbeS2Parameters existing = obj as PbeS2Parameters;
             if (existing != null)
                 return existing;
-            return new PbeS2Parameters(Asn1Sequence.GetInstance(obj));
+            return PbeS2Parameters.GetInstance(Asn1Sequence.GetInstance(obj));
         }
 
         public PbeS2Parameters(KeyDerivationFunc keyDevFunc, EncryptionScheme encScheme)

--- a/crypto/src/crypto/generators/ECKeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/ECKeyPairGenerator.cs
@@ -76,6 +76,10 @@ namespace Org.BouncyCastle.Crypto.Generators
                         throw new InvalidParameterException("unknown key size.");
                 }
 
+                // Set this to make the SubjectPublicKeyInfo contain a named curve
+                // Without it, the SPKI contains explicit curve parameters
+                publicKeyParamSet = oid;
+
                 X9ECParameters ecps = FindECCurveByOid(oid);
 
                 this.parameters = new ECDomainParameters(

--- a/crypto/src/math/BigInteger.cs
+++ b/crypto/src/math/BigInteger.cs
@@ -1240,7 +1240,8 @@ namespace Org.BouncyCastle.Math
         public override bool Equals(
             object obj)
         {
-            if (obj == this)
+            // To avoid a "possible unintended reference comparison" warning
+            if (obj == (object)this)
                 return true;
 
             BigInteger biggie = obj as BigInteger;
@@ -3641,7 +3642,7 @@ namespace Org.BouncyCastle.Math
 
         public static bool operator ==(BigInteger val1, BigInteger val2)
         {
-            return val1.IsEqualMagnitude(val2);
+            return val1.sign == val2.sign && val1.IsEqualMagnitude(val2);
         }
 
         public static bool operator >(BigInteger val1, BigInteger val2)

--- a/crypto/src/math/BigInteger.cs
+++ b/crypto/src/math/BigInteger.cs
@@ -3561,5 +3561,132 @@ namespace Org.BouncyCastle.Math
             //mag[mag.Length - 1 - (n / 32)] ^= (1 << (n % 32));
             return new BigInteger(this.sign, mag, false);
         }
+
+        #region Operators        
+        public static BigInteger operator +(BigInteger val1, BigInteger val2)
+        {
+            return val1.Add(val2);
+        }
+
+        public static BigInteger operator ++(BigInteger value)
+        {
+            return value.Add(BigInteger.One);
+        }
+
+        /// <summary>
+        /// Subtraction (binary minus)
+        /// </summary>
+        /// <param name="val1">BigInteger to subtract from</param>
+        /// <param name="val2">BigInteger to subtract</param>
+        /// <returns>The subtraction of val2 from val1.</returns>
+        public static BigInteger operator -(BigInteger val1, BigInteger val2)
+        {
+            return val1.Subtract(val2);
+        }
+
+        /// <summary>
+        /// Negation (unary minus)
+        /// </summary>
+        /// <param name="value">The value to negate the sign of</param>
+        /// <returns>The negated value.</returns>
+        public static BigInteger operator -(BigInteger value)
+        {
+            return value.Negate();
+        }
+
+        /// <summary>
+        /// Identity (Unary Plus)
+        /// </summary>
+        /// <param name="value">The value to return</param>
+        /// <returns>The value passed to it (basically a no operation). </returns>
+        public static BigInteger operator +(BigInteger value)
+        {
+            return value;
+        }
+
+        public static BigInteger operator --(BigInteger value)
+        {
+            return value.Subtract(BigInteger.One);
+        }
+
+        public static BigInteger operator *(BigInteger val1, BigInteger val2)
+        {
+            return val1.Multiply(val2);
+        }
+
+        public static BigInteger operator /(BigInteger numerator, BigInteger denominator)
+        {
+            return numerator.Divide(denominator);
+        }
+
+        public static BigInteger operator %(BigInteger numerator, BigInteger denominator)
+        {
+            return numerator.Mod(denominator);
+        }
+
+        public static BigInteger operator &(BigInteger val1, BigInteger val2)
+        {
+            return val1.And(val2);
+        }
+
+        public static BigInteger operator |(BigInteger val1, BigInteger val2)
+        {
+            return val1.Or(val2);
+        }
+
+        public static BigInteger operator ^(BigInteger val1, BigInteger val2)
+        {
+            return val1.Xor(val2);
+        }
+
+        public static bool operator ==(BigInteger val1, BigInteger val2)
+        {
+            return val1.IsEqualMagnitude(val2);
+        }
+
+        public static bool operator >(BigInteger val1, BigInteger val2)
+        {
+            return val1.CompareTo(val2) > 0 ? true : false;
+        }
+
+        public static bool operator <(BigInteger val1, BigInteger val2)
+        {
+            return val1.CompareTo(val2) < 0 ? true : false;
+        }
+
+        public static bool operator >=(BigInteger val1, BigInteger val2)
+        {
+            return val1.CompareTo(val2) > -1 ? true : false;
+        }
+
+        public static bool operator <=(BigInteger val1, BigInteger val2)
+        {
+            return val1.CompareTo(val2) < 1 ? true : false;
+        }
+
+        public static bool operator !=(BigInteger val1, BigInteger val2)
+        {
+            return !val1.IsEqualMagnitude(val2);
+        }
+
+        public static BigInteger operator << (BigInteger val1, int val2)
+        {
+            return val1.ShiftLeft(val2);
+        }
+
+        public static BigInteger operator >>(BigInteger val1, int val2)
+        {
+            return val1.ShiftRight(val2);
+        }
+
+        public static BigInteger operator ~(BigInteger value)
+        {
+            // This is the algorithm that Microsoft's System.Numerics.BigInteger
+            // structure uses, rewritten for BouncyCastle to eliminate the
+            // operator - and + method overhead.
+            // This does NOT invert any extra bits in the magnitude.
+            return value.Add(BigInteger.One).Negate();
+        }
+        #endregion
     }
 }

--- a/crypto/src/math/BigInteger.cs
+++ b/crypto/src/math/BigInteger.cs
@@ -3667,7 +3667,7 @@ namespace Org.BouncyCastle.Math
 
         public static bool operator !=(BigInteger val1, BigInteger val2)
         {
-            return !val1.IsEqualMagnitude(val2);
+            return !(val1 == val2);
         }
 
         public static BigInteger operator << (BigInteger val1, int val2)


### PR DESCRIPTION
...ve names, per Jira BMA-101

When publicKeyParamSet is left null, then GenerateKeyPair() does not look up the parameter set to try to save the curve name.  When it's set, the constructor overloads for ECPublicKeyParameters and ECPrivateKeyParameters take the curve name and don't bother with explicit encoding.

This resolves Jira issue BMA-101.