### PR TITLE
Correct duplicate key exception when more than one signer use the same digest algorithm.

### DIFF
--- a/crypto/src/cms/CMSSignedDataGenerator.cs
+++ b/crypto/src/cms/CMSSignedDataGenerator.cs
@@ -93,19 +93,24 @@ namespace Org.BouncyCastle.Cms
             {
                 AlgorithmIdentifier digAlgId = DigestAlgorithmID;
 				string digestName = Helper.GetDigestAlgName(digestOID);
-				IDigest dig = Helper.GetDigestInstance(digestName);
 
 				string signatureName = digestName + "with" + Helper.GetEncryptionAlgName(encOID);
 				ISigner sig = Helper.GetSignatureInstance(signatureName);
 
-				// TODO Optimise the case where more than one signer with same digest
-				if (content != null)
-                {
-                    content.Write(new DigOutputStream(dig));
-				}
+                byte[] hash;
 
-				byte[] hash = DigestUtilities.DoFinal(dig);
-				outer._digests.Add(digestOID, hash.Clone());
+                if (outer._digests.Contains(digestOID))
+                    hash = (byte[])outer._digests[digestOID];
+                else
+                {
+                    IDigest dig = Helper.GetDigestInstance(digestName);
+                    if (content != null)
+                    {
+                        content.Write(new DigOutputStream(dig));
+                    }
+                    hash = DigestUtilities.DoFinal(dig);
+                    outer._digests.Add(digestOID, hash.Clone());
+                }
 
 				sig.Init(true, new ParametersWithRandom(key, random));
 #if NETCF_1_0 || NETCF_2_0 || SILVERLIGHT


### PR DESCRIPTION
When sigin a document, if two or more signers use the same algorithm, an duplicate key exception is generated.

This commit solves the problem.
