### PR TITLE
added an implementation of RSA/ECB/OAEPWithSHA-256AndMGF1Padding as …

### DIFF
--- a/crypto/src/security/CipherUtilities.cs
+++ b/crypto/src/security/CipherUtilities.cs
@@ -85,6 +85,10 @@ namespace Org.BouncyCastle.Security
             OAEPWITHSHA_224ANDMGF1PADDING,
             OAEPWITHSHA256ANDMGF1PADDING,
             OAEPWITHSHA_256ANDMGF1PADDING,
+            OAEPWITHSHA256ANDMGF1WITHSHA256PADDING,
+            OAEPWITHSHA_256ANDMGF1WITHSHA_256PADDING,
+            OAEPWITHSHA256ANDMGF1WITHSHA1PADDING,
+            OAEPWITHSHA_256ANDMGF1WITHSHA_1PADDING,
             OAEPWITHSHA384ANDMGF1PADDING,
             OAEPWITHSHA_384ANDMGF1PADDING,
             OAEPWITHSHA512ANDMGF1PADDING,
@@ -543,7 +547,13 @@ namespace Org.BouncyCastle.Security
                         break;
                     case CipherPadding.OAEPWITHSHA256ANDMGF1PADDING:
                     case CipherPadding.OAEPWITHSHA_256ANDMGF1PADDING:
+                    case CipherPadding.OAEPWITHSHA256ANDMGF1WITHSHA256PADDING:
+                    case CipherPadding.OAEPWITHSHA_256ANDMGF1WITHSHA_256PADDING:
                         asymBlockCipher = new OaepEncoding(asymBlockCipher, new Sha256Digest());
+                        break;
+                    case CipherPadding.OAEPWITHSHA256ANDMGF1WITHSHA1PADDING:
+                    case CipherPadding.OAEPWITHSHA_256ANDMGF1WITHSHA_1PADDING:
+                        asymBlockCipher = new OaepEncoding(asymBlockCipher, new Sha256Digest(), new Sha1Digest(), null);
                         break;
                     case CipherPadding.OAEPWITHSHA384ANDMGF1PADDING:
                     case CipherPadding.OAEPWITHSHA_384ANDMGF1PADDING:


### PR DESCRIPTION
… it is implemented in java as: RSA/ECB/OAEPWithSHA-256AndMGF1WithSHA-1Padding

**Added compatibility with Java:**

In Java this Cipher : `RSA/ECB/OAEPWithSHA-256AndMGF1` has the MGF1 Padding "SHA1". In C#
the same Cipher `RSA/ECB/OAEPWithSHA-256AndMGF1` has the MGF1 Padding "SHA256".

The current BC C# implementation is unable to de/en-crypt data in such a way that it would be compatible with a Java counterpart.

Therefore the `RSA/ECB/OAEPWithSHA-256AndMGF1WithSHA-1Padding` configuration has been added to allow this interoperability. For completeness the `RSA/ECB/OAEPWithSHA-256AndMGF1WithSHA-256Padding` has been added as well.

Related to https://github.com/bcgit/bc-csharp/issues/53