### PR TITLE
CmsSignedData: Don't assume the signed content is a Asn1OctetString object

### DIFF
--- a/crypto/src/cms/CMSSignedData.cs
+++ b/crypto/src/cms/CMSSignedData.cs
@@ -135,13 +135,10 @@ namespace Org.BouncyCastle.Cms
 			//
 			if (signedData.EncapContentInfo.Content != null)
 			{
+				var content = signedData.EncapContentInfo.Content;
 				this.signedContent = new CmsProcessableByteArray(
-					((Asn1OctetString)(signedData.EncapContentInfo.Content)).GetOctets());
+					content.GetEncoded());
 			}
-//			else
-//			{
-//				this.signedContent = null;
-//			}
 		}
 
 		/// <summary>Return the version number for this object.</summary>


### PR DESCRIPTION
This PR fixes an issue in the `CmsSignedData` where the constructor would assume that the signed content is an `Asn1OctetString` object. That's not always true - in my case, the data was a `DerSequence`.