### PR TITLE
Set signature through ISignatureFactory

### DIFF
--- a/crypto/src/x509/X509V2AttributeCertificateGenerator.cs
+++ b/crypto/src/x509/X509V2AttributeCertificateGenerator.cs
@@ -164,6 +164,7 @@ namespace Org.BouncyCastle.X509
 				acInfoGen.SetExtensions(extGenerator.Generate());
 			}
 
+          acInfoGen.SetSignature((AlgorithmIdentifier)signatureCalculatorFactory.AlgorithmDetails);
 			AttributeCertificateInfo acInfo = acInfoGen.GenerateAttributeCertificateInfo();
 
             byte[] encoded = acInfo.GetDerEncoded();


### PR DESCRIPTION
Using Generate with ISignatureFactory is the preferred way to use the generator. However the signature could only be set using obsoleted methods.
The change just uses the same signature algorithm information provided by the ISignatureFactory, which was already used in line 179 beforehand.
