### PR TITLE
SignerInfo: Only write attribute object if it contains data

### DIFF
--- a/crypto/src/asn1/cms/SignerInfo.cs
+++ b/crypto/src/asn1/cms/SignerInfo.cs
@@ -167,14 +167,14 @@ namespace Org.BouncyCastle.Asn1.Cms
             Asn1EncodableVector v = new Asn1EncodableVector(
                 version, sid, digAlgorithm);
 
-            if (authenticatedAttributes != null)
+            if (authenticatedAttributes != null && authenticatedAttributes.Count > 0)
             {
                 v.Add(new DerTaggedObject(false, 0, authenticatedAttributes));
             }
 
             v.Add(digEncryptionAlgorithm, encryptedDigest);
 
-            if (unauthenticatedAttributes != null)
+            if (unauthenticatedAttributes != null && unauthenticatedAttributes.Count > 0)
             {
                 v.Add(new DerTaggedObject(false, 1, unauthenticatedAttributes));
             }

--- a/crypto/src/cms/CMSSignedDataGenerator.cs
+++ b/crypto/src/cms/CMSSignedDataGenerator.cs
@@ -143,13 +143,11 @@ namespace Org.BouncyCastle.Cms
 #endif
 
 				Asn1Set signedAttr = null;
-				if (sAttr != null)
+                IDictionary parameters = outer.GetBaseParameters(contentType, digAlgId, hash);
+                Asn1.Cms.AttributeTable signed = sAttr == null ? null : sAttr.GetAttributes(parameters);
+
+				if (signed != null && signed.Count > 0)
 				{
-					IDictionary parameters = outer.GetBaseParameters(contentType, digAlgId, hash);
-
-//					Asn1.Cms.AttributeTable signed = sAttr.GetAttributes(Collections.unmodifiableMap(parameters));
-					Asn1.Cms.AttributeTable signed = sAttr.GetAttributes(parameters);
-
                     if (contentType == null) //counter signature
                     {
                         if (signed != null && signed[CmsAttributes.ContentType] != null)
@@ -187,7 +185,10 @@ namespace Org.BouncyCastle.Cms
 
 					// TODO Validate proposed unsigned attributes
 
-					unsignedAttr = outer.GetAttributeSet(unsigned);
+                    if (unsigned.Count > 0)
+                    {
+						unsignedAttr = outer.GetAttributeSet(unsigned);
+                    }
 				}
 
 				// TODO[RSAPSS] Need the ability to specify non-default parameters

--- a/crypto/src/cms/CMSSignedGenerator.cs
+++ b/crypto/src/cms/CMSSignedGenerator.cs
@@ -182,7 +182,7 @@ namespace Org.BouncyCastle.Cms
         internal protected virtual Asn1Set GetAttributeSet(
             Asn1.Cms.AttributeTable attr)
         {
-            return attr == null
+            return attr == null || attr.Count == 0
                 ? null
                 : new DerSet(attr.ToAsn1EncodableVector());
         }


### PR DESCRIPTION
If a `CmsSignedObject` is signed without any attributes (as seen, for example, for `.apk` packages), Bouncy Castle would write out a 0-length object. That doesn't seem to be valid; you should omit the object all together.

This PR addresses that issue.
