### PR TITLE
Enable subclassing of the DerOutputStream

### DIFF
--- a/crypto/src/asn1/DerOutputStream.cs
+++ b/crypto/src/asn1/DerOutputStream.cs
@@ -39,7 +39,7 @@ namespace Org.BouncyCastle.Asn1
 			}
 		}
 
-		internal void WriteEncoded(
+		public virtual void WriteEncoded(
 			int		tag,
 			byte[]	bytes)
 		{
@@ -48,7 +48,7 @@ namespace Org.BouncyCastle.Asn1
 			Write(bytes, 0, bytes.Length);
 		}
 
-        internal void WriteEncoded(
+        public virtual void WriteEncoded(
             int     tag,
             byte    first,
             byte[]  bytes)
@@ -59,7 +59,7 @@ namespace Org.BouncyCastle.Asn1
             Write(bytes, 0, bytes.Length);
         }
 
-        internal void WriteEncoded(
+        public virtual void WriteEncoded(
 			int		tag,
 			byte[]	bytes,
 			int		offset,
@@ -70,7 +70,7 @@ namespace Org.BouncyCastle.Asn1
 			Write(bytes, offset, length);
 		}
 
-		internal void WriteTag(
+		public virtual void WriteTag(
 			int	flags,
 			int	tagNo)
 		{
@@ -104,7 +104,7 @@ namespace Org.BouncyCastle.Asn1
 			}
 		}
 
-		internal void WriteEncoded(
+		public virtual void WriteEncoded(
 			int		flags,
 			int		tagNo,
 			byte[]	bytes)
@@ -114,7 +114,7 @@ namespace Org.BouncyCastle.Asn1
 			Write(bytes, 0, bytes.Length);
 		}
 
-		protected void WriteNull()
+		protected virtual void WriteNull()
 		{
 			WriteByte(Asn1Tags.Null);
 			WriteByte(0x00);


### PR DESCRIPTION
I use Bouncy Castle to generate signatures for iOS and Android applications (as PKCS#7 objects).
It turns out that these mobile operating systems are very sensitive to how these signatures are serialized to disk.
For example, Android seems to bark at any object with undefined length, whereas iOS can't handle objects with a length greater than 4096 _unless_ they are marked as undefined length.

This isn't something that can be fixed in Bouncy Castle itself, as all of these are implementation details which will differ between the systems you interact with.

Hence, I propose to enable subclassing of the `DerOutputStream`, so that those who want greater control of how PCKS#7 objects (or any other object, for that matter) are serialized to disk can subclass  `DerOutputStream` and implement the required format themselves.

This PR implements that.

Makes sense?
