### PR TITLE
Implement HKDF

### DIFF
--- a/crypto/BouncyCastle.csproj
+++ b/crypto/BouncyCastle.csproj
@@ -1494,6 +1494,7 @@
     <Compile Include="src\x509\store\X509CrlStoreSelector.cs" />
     <Compile Include="src\x509\store\X509StoreException.cs" />
     <Compile Include="src\x509\store\X509StoreFactory.cs" />
+    <Compile Include="src\crypto\parameters\HKDFParameters.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Contributors.html" />

--- a/crypto/BouncyCastle.csproj
+++ b/crypto/BouncyCastle.csproj
@@ -1495,6 +1495,7 @@
     <Compile Include="src\x509\store\X509StoreException.cs" />
     <Compile Include="src\x509\store\X509StoreFactory.cs" />
     <Compile Include="src\crypto\parameters\HKDFParameters.cs" />
+    <Compile Include="src\crypto\generators\HKDFBytesGenerator.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="Contributors.html" />

--- a/crypto/src/crypto/generators/HKDFBytesGenerator.cs
+++ b/crypto/src/crypto/generators/HKDFBytesGenerator.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using Org.BouncyCastle.Crypto;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Crypto.Macs;
+using System.Collections.Generic;
+
+namespace Org.BouncyCastle.Crypto.Generators
+{
+	/// <summary>
+	/// HMAC-based Extract-and-Expand Key Derivation Function (HKDF) implemented according to IETF RFC 5869, May 2010 as specified by H. Krawczyk, IBM Research & P. Eronen, Nokia. 
+	/// It uses a HMac internally to compute de OKM (output keying material) and is likely to have better security properties than KDF's based on just a hash function.
+	/// </summary>
+	public class HKDFBytesGenerator : IDerivationFunction
+	{
+		private HKDFParameters parameters;
+
+		public IDigest Digest { get; private set; }
+
+		/// <summary>
+		/// Creates a HKDFBytesGenerator based on the given hash function.
+		/// </summary>
+		/// <param name="hash">The hash to be used for the key derivation.</param>
+		public HKDFBytesGenerator (IDigest hash)
+		{
+			if (hash == null)
+				throw new ArgumentNullException ("hash");
+			
+			this.Digest = hash;
+		}
+
+		/// <summary>
+		/// Initialise the byte generator with parameters.
+		/// </summary>
+		/// <param name="parameters">Parameters for the KDF. Must be of type HKDFParameters.</param>
+		public void Init (IDerivationParameters parameters)
+		{
+			if (parameters == null)
+				throw new ArgumentNullException ("parameters");
+
+			this.parameters = parameters as HKDFParameters;
+			if (parameters == null)
+				throw new ArgumentException ("Parameters of type HKDFParameters needed.", "parameters");
+		}
+
+		/// <summary>
+		/// Generates the derived key.
+		/// </summary>
+		/// <returns>The length of the derived key.</returns>
+		/// <param name="output">Array where the derived key is to be stored. Must be long enough.</param>
+		/// <param name="outOff">Offset in <paramref name="output"/>, where the derived key is written.</param>
+		/// <param name="length">Length of the derived key.</param>
+		public int GenerateBytes (byte[] output, int outOff, int length)
+		{
+			if (output == null)
+				throw new ArgumentNullException ("output");
+			if (outOff < 0)
+				throw new ArgumentException ("Offset must not be negative", "outOff");
+			if (length < 0)
+				throw new ArgumentException ("Length must not be negative.", "length");
+			if (output.Length < length + outOff)
+				throw new DataLengthException ("Output is not big enough for the specified length.");
+			// RFC 5869: HashLen denotes the length of the hash function output in octets
+			int hashLen = Digest.GetDigestSize ();
+			//RFC 5869: length of output keying material in octets (<= 255*HashLen) 
+			if (length > 255 * hashLen)
+				throw new DataLengthException ("Length must not exceed 255*HashLen");
+			
+			//RFC 5869: optional salt value (a non-secret random value); if not provided, it is set to a string of HashLen zeros.
+			byte[] salt = parameters.Salt;
+			if (salt == null || salt.Length == 0)
+				salt = new byte[hashLen];
+			
+			HMac prf = new HMac (Digest);
+			KeyParameter hmacParameters;
+
+			byte[] prk;
+			if (parameters.SkipExtract) 
+				// No 'extract' step, just use the ikm as the pseudo random key
+				prk = parameters.Ikm;
+			else {
+				// Step 1: Extract
+				// RFC 5869: PRK = HMAC-Hash(salt, IKM)
+				prk = new byte[hashLen];
+				hmacParameters = new KeyParameter (salt);
+				prf.Init (hmacParameters);
+				prf.BlockUpdate (parameters.Ikm, 0, parameters.Ikm.Length);
+				prf.DoFinal (prk, 0);
+			}
+
+			//Step 2: Expand
+			int blockCount = (int)System.Math.Ceiling((double)length/hashLen);
+			//RFC 5869: 
+			//  T = T(1) | T(2) | T(3) | ... | T(N)
+			// OKM = first L octets of T
+			List<byte> okm = new List<byte> ();
+			//RFC 5869: T(0) = empty string (zero length)
+			byte[] block = new byte[hashLen];
+			byte[] lastBlock = new byte[0];
+			// RFC 5869:
+			// T(1) = HMAC-Hash(PRK, T(0) | info | 0x01)
+			// T(2) = HMAC-Hash(PRK, T(1) | info | 0x02)
+			// T(3) = HMAC-Hash(PRK, T(2) | info | 0x03)
+			//	...
+			prf.Reset();
+			hmacParameters = new KeyParameter(prk);
+			prf.Init(hmacParameters);
+			for(int i=1; i <= blockCount; ++i) {
+				List<byte> blockData = new List<byte> (lastBlock);
+				blockData.AddRange (parameters.Info);
+				blockData.AddRange (new byte[]{(byte)i});
+				prf.BlockUpdate (blockData.ToArray (), 0, blockData.Count);
+				prf.DoFinal (block, 0);
+				okm.AddRange (block);
+				lastBlock = block;
+			}
+			okm.CopyTo (0, output, outOff, length);
+			//Array.Copy(okm.ToArray(), 0, output, outOff, length);
+
+			//return the length of the data written to output
+			return length;
+		}
+	}
+}
+

--- a/crypto/src/crypto/parameters/HKDFParameters.cs
+++ b/crypto/src/crypto/parameters/HKDFParameters.cs
@@ -1,0 +1,58 @@
+﻿using System;
+
+namespace Org.BouncyCastle.Crypto.Parameters
+{
+	/// <summary>
+	/// Parameter class for the HKDFBytesGenerator class.
+	/// </summary>
+	public class HKDFParameters : IDerivationParameters
+	{
+		/// <summary>
+		/// Gets or sets the input keying material or seed.
+		/// </summary>
+		public byte[] Ikm { get; private set; }
+
+		/// <summary>
+		/// The info field, which may be empty (null is converted to empty)
+		/// </summary>
+		public byte[] Info { get; private set; }
+
+		/// <summary>
+		/// The salt, or null if the salt should be generated as a byte array of HashLen zeros.
+		/// </summary>
+		public byte[] Salt { get; private set; }
+
+		/// <summary>
+		/// Sets if step 1: extract has to be skipped or not
+		/// </summary>
+		public bool SkipExtract { get; private set; }
+
+		public HKDFParameters (byte[] ikm, byte[] salt, byte[] info)
+		{
+			// validate the input values
+			if (ikm == null)
+				throw new ArgumentNullException ("ikm");
+			if (ikm.Length == 0)
+				throw new ArgumentException ("Input key material must not be empty.", "ikm");
+			
+			this.Ikm = ikm;
+			// A null value for info is converted to an empty array
+			if (info != null)
+				this.Info = info;
+			else
+				this.Info = new byte[0];
+
+			this.Salt = salt;
+
+			this.SkipExtract = false;
+		}
+
+		public static HKDFParameters SkipExtractParameters(byte[] ikm, byte[] info)
+		{
+			return new HKDFParameters(ikm, null, info) { SkipExtract = true};
+		}
+
+		
+	}
+}
+

--- a/crypto/test/UnitTests.csproj
+++ b/crypto/test/UnitTests.csproj
@@ -432,6 +432,7 @@
     <Compile Include="src\util\test\TestFailedException.cs" />
     <Compile Include="src\util\test\UncloseableStream.cs" />
     <Compile Include="src\x509\test\TestCertificateGen.cs" />
+    <Compile Include="src\crypto\test\HKDFBytesGeneratorTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="data\crypto\SHA3TestVectors.txt" />

--- a/crypto/test/src/crypto/test/HKDFBytesGeneratorTest.cs
+++ b/crypto/test/src/crypto/test/HKDFBytesGeneratorTest.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace UnitTests
+{
+	public class HKDFBytesGeneratorTest
+	{
+		public HKDFBytesGeneratorTest ()
+		{
+		}
+	}
+}
+

--- a/crypto/test/src/crypto/test/HKDFBytesGeneratorTest.cs
+++ b/crypto/test/src/crypto/test/HKDFBytesGeneratorTest.cs
@@ -1,11 +1,317 @@
 ﻿using System;
+using NUnit.Framework;
+using Org.BouncyCastle.Crypto.Parameters;
+using Org.BouncyCastle.Utilities.Encoders;
+using Org.BouncyCastle.Crypto.Generators;
+using Org.BouncyCastle.Crypto.Digests;
 
-namespace UnitTests
+namespace Org.BouncyCastle.Crypto.Tests
 {
+	[TestFixture()]
 	public class HKDFBytesGeneratorTest
 	{
-		public HKDFBytesGeneratorTest ()
+		/* RFC 5869:
+			 * A.1.  Test Case 1
+
+   Basic test case with SHA-256
+
+   Hash = SHA-256
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 octets)
+   salt = 0x000102030405060708090a0b0c (13 octets)
+   info = 0xf0f1f2f3f4f5f6f7f8f9 (10 octets)
+   L    = 42
+
+   PRK  = 0x077709362c2e32df0ddc3f0dc47bba63
+          90b6c73bb50f9c3122ec844ad7c2b3e5 (32 octets)
+   OKM  = 0x3cb25f25faacd57a90434f64d0362f2a
+          2d2d0a90cf1a5a4c5db02d56ecc4c5bf
+          34007208d5b887185865 (42 octets)
+          */
+		[TestCase("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "000102030405060708090a0b0c", "f0f1f2f3f4f5f6f7f8f9", 42, @"3cb25f25faacd57a90434f64d0362f2a
+          2d2d0a90cf1a5a4c5db02d56ecc4c5bf
+          34007208d5b887185865")]
+		/* RFC 5869:
+		 * A.2.  Test Case 2
+
+   Test with SHA-256 and longer inputs/outputs
+
+   Hash = SHA-256
+   IKM  = 0x000102030405060708090a0b0c0d0e0f
+          101112131415161718191a1b1c1d1e1f
+          202122232425262728292a2b2c2d2e2f
+          303132333435363738393a3b3c3d3e3f
+          404142434445464748494a4b4c4d4e4f (80 octets)
+   salt = 0x606162636465666768696a6b6c6d6e6f
+          707172737475767778797a7b7c7d7e7f
+          808182838485868788898a8b8c8d8e8f
+          909192939495969798999a9b9c9d9e9f
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf (80 octets)
+   info = 0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebf
+          c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
+          d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          e0e1e2e3e4e5e6e7e8e9eaebecedeeef
+          f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff (80 octets)
+   L    = 82
+
+   PRK  = 0x06a6b88c5853361a06104c9ceb35b45c
+          ef760014904671014a193f40c15fc244 (32 octets)
+   OKM  = 0xb11e398dc80327a1c8e7f78c596a4934
+          4f012eda2d4efad8a050cc4c19afa97c
+          59045a99cac7827271cb41c65e590e09
+          da3275600c2f09b8367793a9aca3db71
+          cc30c58179ec3e87c14c01d5c1f3434f
+          1d87 (82 octets)
+          */
+		[TestCase(@"000102030405060708090a0b0c0d0e0f
+          101112131415161718191a1b1c1d1e1f
+          202122232425262728292a2b2c2d2e2f
+          303132333435363738393a3b3c3d3e3f
+          404142434445464748494a4b4c4d4e4f",
+			@"606162636465666768696a6b6c6d6e6f
+          707172737475767778797a7b7c7d7e7f
+          808182838485868788898a8b8c8d8e8f
+          909192939495969798999a9b9c9d9e9f
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+			@"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf
+          c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
+          d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          e0e1e2e3e4e5e6e7e8e9eaebecedeeef
+          f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+			82, @"b11e398dc80327a1c8e7f78c596a4934
+          4f012eda2d4efad8a050cc4c19afa97c
+          59045a99cac7827271cb41c65e590e09
+          da3275600c2f09b8367793a9aca3db71
+          cc30c58179ec3e87c14c01d5c1f3434f
+          1d87")]
+		/* RFC 5869:
+		 * A.3.  Test Case 3
+
+   Test with SHA-256 and zero-length salt/info
+
+   Hash = SHA-256
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 octets)
+   salt = (0 octets)
+   info = (0 octets)f
+   L    = 42
+
+   PRK  = 0x19ef24a32c717b167f33a91d6f648bdf
+          96596776afdb6377ac434c1c293ccb04 (32 octets)
+   OKM  = 0x8da4e775a563c18f715f802a063c5a31
+          b8a11f5c5ee1879ec3454e5f3c738d2d
+          9d201395faa4b61a96c8 (42 octets)
+          */
+		[TestCase("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "", 42, @"8da4e775a563c18f715f802a063c5a31
+          b8a11f5c5ee1879ec3454e5f3c738d2d
+          9d201395faa4b61a96c8")]
+		public void GenerateBytesSha256Test(string ikmHex, string saltHex, string infoHex, int length, string expectedOkmHex)
 		{
+			IDigest hash = new Sha256Digest ();
+			GenerateBytesTest (hash, ikmHex, saltHex, infoHex, length, expectedOkmHex);
+		}
+
+		/* RFC 5869:
+		 * A.4.  Test Case 4
+
+   Basic test case with SHA-1
+
+   Hash = SHA-1
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b (11 octets)
+   salt = 0x000102030405060708090a0b0c (13 octets)
+   info = 0xf0f1f2f3f4f5f6f7f8f9 (10 octets)
+   L    = 42
+
+   PRK  = 0x9b6c18c432a7bf8f0e71c8eb88f4b30baa2ba243 (20 octets)
+   OKM  = 0x085a01ea1b10f36933068b56efa5ad81
+          a4f14b822f5b091568a9cdd4f155fda2
+          c22e422478d305f3f896 (42 octets)
+          */
+		[TestCase("0b0b0b0b0b0b0b0b0b0b0b", "000102030405060708090a0b0c", "f0f1f2f3f4f5f6f7f8f9", 42, @"085a01ea1b10f36933068b56efa5ad81
+          a4f14b822f5b091568a9cdd4f155fda2
+          c22e422478d305f3f896")]
+		/* RFC 5869:  
+		 * A.5.  Test Case 5
+
+   Test with SHA-1 and longer inputs/outputs
+
+   Hash = SHA-1
+   IKM  = 0x000102030405060708090a0b0c0d0e0f
+          101112131415161718191a1b1c1d1e1f
+          202122232425262728292a2b2c2d2e2f
+          303132333435363738393a3b3c3d3e3f
+          404142434445464748494a4b4c4d4e4f (80 octets)
+   salt = 0x606162636465666768696a6b6c6d6e6f
+          707172737475767778797a7b7c7d7e7f
+          808182838485868788898a8b8c8d8e8f
+          909192939495969798999a9b9c9d9e9f
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf (80 octets)
+   info = 0xb0b1b2b3b4b5b6b7b8b9babbbcbdbebf
+          c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
+          d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          e0e1e2e3e4e5e6e7e8e9eaebecedeeef
+          f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff (80 octets)
+   L    = 82
+
+   PRK  = 0x8adae09a2a307059478d309b26c4115a224cfaf6 (20 octets)
+   OKM  = 0x0bd770a74d1160f7c9f12cd5912a06eb
+          ff6adcae899d92191fe4305673ba2ffe
+          8fa3f1a4e5ad79f3f334b3b202b2173c
+          486ea37ce3d397ed034c7f9dfeb15c5e
+          927336d0441f4c4300e2cff0d0900b52
+          d3b4 (82 octets)
+*/
+		[TestCase(@"000102030405060708090a0b0c0d0e0f
+          101112131415161718191a1b1c1d1e1f
+          202122232425262728292a2b2c2d2e2f
+          303132333435363738393a3b3c3d3e3f
+          404142434445464748494a4b4c4d4e4f",
+			@"606162636465666768696a6b6c6d6e6f
+          707172737475767778797a7b7c7d7e7f
+          808182838485868788898a8b8c8d8e8f
+          909192939495969798999a9b9c9d9e9f
+          a0a1a2a3a4a5a6a7a8a9aaabacadaeaf",
+			@"b0b1b2b3b4b5b6b7b8b9babbbcbdbebf
+          c0c1c2c3c4c5c6c7c8c9cacbcccdcecf
+          d0d1d2d3d4d5d6d7d8d9dadbdcdddedf
+          e0e1e2e3e4e5e6e7e8e9eaebecedeeef
+          f0f1f2f3f4f5f6f7f8f9fafbfcfdfeff",
+			82, @"0bd770a74d1160f7c9f12cd5912a06eb
+          ff6adcae899d92191fe4305673ba2ffe
+          8fa3f1a4e5ad79f3f334b3b202b2173c
+          486ea37ce3d397ed034c7f9dfeb15c5e
+          927336d0441f4c4300e2cff0d0900b52
+          d3b4")]
+		/* RFC 5869: 
+		 * A.6.  Test Case 6
+
+   Test with SHA-1 and zero-length salt/info
+
+   Hash = SHA-1
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 octets)
+   salt = (0 octets)
+   info = (0 octets)
+   L    = 42
+
+   PRK  = 0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01 (20 octets)
+   OKM  = 0x0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918 (42 octets)
+          */
+		[TestCase("0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b", "", "", 42, @"0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918")]
+		/* RFC 5869:
+		 * A.7.  Test Case 7
+
+   Test with SHA-1, salt not provided (defaults to HashLen zero octets),
+   zero-length info
+
+   Hash = SHA-1
+   IKM  = 0x0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c (22 octets)
+   salt = not provided (defaults to HashLen zero octets)
+   info = (0 octets)
+   L    = 42
+
+   PRK  = 0x2adccada18779e7c2077ad2eb19d3f3e731385dd (20 octets)
+   OKM  = 0x2c91117204d745f3500d636a62f64f0a
+          b3bae548aa53d423b0d1f27ebba6f5e5
+          673a081d70cce7acfc48 (42 octets)
+          */
+		[TestCase("0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c0c", null, "", 42, @"2c91117204d745f3500d636a62f64f0a
+          b3bae548aa53d423b0d1f27ebba6f5e5
+          673a081d70cce7acfc48")]
+		public void GenerateBytesSha1Test(string ikmHex, string saltHex, string infoHex, int length, string expectedOkmHex)
+		{
+			IDigest hash = new Sha1Digest ();
+			GenerateBytesTest (hash, ikmHex, saltHex, infoHex, length, expectedOkmHex);
+		}
+
+		public void GenerateBytesTest(IDigest hash, string ikmHex, string saltHex, string infoHex, int length, string expectedOkmHex)
+		{
+			byte[] salt;
+			if (saltHex == null)
+				salt = null;
+			else
+				salt = Hex.Decode (saltHex);
+			HKDFParameters parameters = new HKDFParameters (Hex.Decode (ikmHex), salt, Hex.Decode(infoHex));
+			HKDFBytesGenerator kdf = new HKDFBytesGenerator (hash);
+			byte[] okm = new byte[length];
+			kdf.Init (parameters);
+			Assert.That (kdf.GenerateBytes (okm, 0, length), Is.EqualTo (length));
+			byte[] expectedOkm = Hex.Decode (expectedOkmHex);
+			Assert.That (okm.Length, Is.EqualTo (expectedOkm.Length));
+			Assert.That(okm, Is.EqualTo(expectedOkm));
+		}
+
+		[Test()]
+		public void SkipExtractText()
+		{
+			/* RFC 5869: 
+		 * A.6.  Test Case 6
+
+   Test with SHA-1 and zero-length salt/info
+
+   Hash = SHA-1
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 octets)
+   salt = (0 octets)
+   info = (0 octets)
+   L    = 42
+
+   PRK  = 0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01 (20 octets)
+   OKM  = 0x0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918 (42 octets)
+          */
+			string prkHex = "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01";
+			int length = 42;
+			string expectedOkmHex = @"0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918";
+			
+			HKDFParameters parameters = HKDFParameters.SkipExtractParameters (Hex.Decode (prkHex), new byte[0]);
+			Assert.That (parameters.SkipExtract, Is.True);
+			HKDFBytesGenerator kdf = new HKDFBytesGenerator (new Sha1Digest ());
+			byte[] okm = new byte[length];
+			kdf.Init (parameters);
+			Assert.That (kdf.GenerateBytes (okm, 0, length), Is.EqualTo (length));
+			byte[] expectedOkm = Hex.Decode (expectedOkmHex);
+			Assert.That (okm.Length, Is.EqualTo (expectedOkm.Length));
+			Assert.That(okm, Is.EqualTo(expectedOkm));
+		}
+
+		[Test()]
+		public void GenerateBytesOffsetTest()
+		{
+			/* RFC 5869: 
+		 * A.6.  Test Case 6
+
+   Test with SHA-1 and zero-length salt/info
+
+   Hash = SHA-1
+   IKM  = 0x0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b (22 octets)
+   salt = (0 octets)
+   info = (0 octets)
+   L    = 42
+
+   PRK  = 0xda8c8a73c7fa77288ec6f5e7c297786aa0d32d01 (20 octets)
+   OKM  = 0x0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918 (42 octets)
+          */
+			string prkHex = "da8c8a73c7fa77288ec6f5e7c297786aa0d32d01";
+			int length = 42;
+			string expectedOkmHex = @"0ac1af7002b3d761d1e55298da9d0506
+          b9ae52057220a306e07b6b87e8df21d0
+          ea00033de03984d34918";
+
+			HKDFParameters parameters = HKDFParameters.SkipExtractParameters (Hex.Decode (prkHex), new byte[0]);
+			Assert.That (parameters.SkipExtract, Is.True);
+			HKDFBytesGenerator kdf = new HKDFBytesGenerator (new Sha1Digest ());
+			byte[] okm = new byte[length+3];
+			kdf.Init (parameters);
+			Assert.That (kdf.GenerateBytes (okm, 3, length), Is.EqualTo (length));
+			byte[] expectedOkm = Hex.Decode ("000000"+expectedOkmHex);
+			Assert.That (okm.Length, Is.EqualTo (expectedOkm.Length));
+			Assert.That(okm, Is.EqualTo(expectedOkm));
 		}
 	}
 }


### PR DESCRIPTION
I have implemented the *HKDFBytesGenerator* class from the java API.
There is a unit test available, but it is a standard nUnit test and does not use BouncyCastle's ITest interface. I hope that is OK.