### PR TITLE
BouncyCastle.csproj: Added trailing slash to OutputPath for compatibility with MSBuild v2

### DIFF
--- a/crypto/BouncyCastle.csproj
+++ b/crypto/BouncyCastle.csproj
@@ -16,8 +16,8 @@
     <DebugSymbols>true</DebugSymbols>
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\lib\net20</OutputPath>
-    <IntermediateOutputPath>obj\Debug\lib\net20</IntermediateOutputPath>
+    <OutputPath>bin\Debug\lib\net20\</OutputPath>
+    <IntermediateOutputPath>obj\Debug\lib\net20\</IntermediateOutputPath>
     <DefineConstants>DEBUG;TRACE;INCLUDE_IDEA;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -25,8 +25,8 @@
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release\lib\net20</OutputPath>
-    <IntermediateOutputPath>obj\Release\lib\net20</IntermediateOutputPath>
+    <OutputPath>bin\Release\lib\net20\</OutputPath>
+    <IntermediateOutputPath>obj\Release\lib\net20\</IntermediateOutputPath>
     <DefineConstants>TRACE;INCLUDE_IDEA;</DefineConstants>
     <DocumentationFile>doc\BouncyCastle.xml</DocumentationFile>
     <ErrorReport>prompt</ErrorReport>


### PR DESCRIPTION
Without this fix, MSBuild will name the output file 'net20BouncyCastle.dll'.
This change is 100% compatible with newer versions of MSBuild.
p.s. When setting the output path with the Visual Studio GUI (any version I tested) a trailing slash is being used.