### PR TITLE
Adding compatibility with Pkcs5S2 certificates with HMAC256

### DIFF
--- a/crypto/src/security/DigestUtilities.cs
+++ b/crypto/src/security/DigestUtilities.cs
@@ -47,7 +47,10 @@ namespace Org.BouncyCastle.Security
             algorithms[PkcsObjectIdentifiers.MD2.Id] = "MD2";
             algorithms[PkcsObjectIdentifiers.MD4.Id] = "MD4";
             algorithms[PkcsObjectIdentifiers.MD5.Id] = "MD5";
-
+            
+            algorithms[PkcsObjectIdentifiers.IdHmacWithSha1.Id] = "SHA-1";
+            algorithms[PkcsObjectIdentifiers.IdHmacWithSha256.Id] = "SHA-256";
+            
             algorithms["SHA1"] = "SHA-1";
             algorithms[OiwObjectIdentifiers.IdSha1.Id] = "SHA-1";
             algorithms["SHA224"] = "SHA-224";

--- a/crypto/src/security/PbeUtilities.cs
+++ b/crypto/src/security/PbeUtilities.cs
@@ -217,7 +217,7 @@ namespace Org.BouncyCastle.Security
             }
             else if (type.Equals(Pkcs5S2))
             {
-                generator = new Pkcs5S2ParametersGenerator();
+                generator = new Pkcs5S2ParametersGenerator(digest);
             }
             else if (type.Equals(Pkcs12))
             {
@@ -426,8 +426,10 @@ namespace Org.BouncyCastle.Security
                     ?	pbeParams.KeyLength.IntValue * 8
                     :	GeneratorUtilities.GetDefaultKeySize(encOid);
 
+                IDigest digest = DigestUtilities.GetDigest(pbeParams.Prf.Algorithm);
+                
                 PbeParametersGenerator gen = MakePbeGenerator(
-                    (string)algorithmType[mechanism], null, keyBytes, salt, iterationCount);
+                    (string)algorithmType[mechanism], digest, keyBytes, salt, iterationCount);
 
                 parameters = gen.GenerateDerivedParameters(encOid.Id, keyLength);
 


### PR DESCRIPTION
Do not use the default HMAC with default SHA1 digest anymore. We use digest indicated in pbeParameters.Prf.Algorithm. Tested with HMAC/SHA1 and HMAC/SHA256 on Pkcs5S2 certificates.