### PR TITLE
Supply OrderN and CofactorH to constructor of FpCurve if provided

### DIFF
--- a/crypto/src/asn1/x9/X9Curve.cs
+++ b/crypto/src/asn1/x9/X9Curve.cs
@@ -64,6 +64,13 @@ namespace Org.BouncyCastle.Asn1.X9
                 X9FieldElement x9A = new X9FieldElement(q, (Asn1OctetString) seq[0]);
                 X9FieldElement x9B = new X9FieldElement(q, (Asn1OctetString) seq[1]);
                 curve = new FpCurve(q, x9A.Value.ToBigInteger(), x9B.Value.ToBigInteger());
+
+                if (seq.Count == 4)
+                {
+                    BigInteger x9OrderN = ((DerInteger)seq[2]).Value;
+                    BigInteger x9CofactorH = ((DerInteger)seq[3]).Value;
+                    curve = new FpCurve(q, x9A.Value.ToBigInteger(), x9B.Value.ToBigInteger(), x9OrderN, x9CofactorH);
+                }
             }
             else
             {


### PR DESCRIPTION
FpCurve has a constructor where the order N and cofactor H can be supplied. This pull request uses this constructor when the parameters are supplied in the Asn1Sequence (count == 4).
For the F2mCurve it is still a TODO (that was there already), but my knowledge of crypto (and my time) is currently not sufficient to implement that as well.

I made this because I needed it (redefined the class in my own project) and I thought to share it and improve BC. I hope this is added in a next release.