### PR TITLE
ECDSA Plain support

### DIFF
--- a/crypto/BouncyCastle.csproj
+++ b/crypto/BouncyCastle.csproj
@@ -51,6 +51,7 @@
     <Compile Include="bzip2\src\CBZip2OutputStream.cs" />
     <Compile Include="bzip2\src\CRC.cs" />
     <Compile Include="src\asn1\BERBitString.cs" />
+    <Compile Include="src\asn1\bsi\BSIObjectIdentifiers.cs" />
     <Compile Include="src\AssemblyInfo.cs" />
     <Compile Include="src\asn1\ASN1Generator.cs" />
     <Compile Include="src\asn1\ASN1OctetStringParser.cs" />

--- a/crypto/src/asn1/bsi/BSIObjectIdentifiers.cs
+++ b/crypto/src/asn1/bsi/BSIObjectIdentifiers.cs
@@ -1,0 +1,36 @@
+﻿namespace Org.BouncyCastle.Asn1.Bsi
+{
+    public sealed class BsiObjectIdentifiers
+    {
+        /**
+         * See https://www.bsi.bund.de/cae/servlet/contentblob/471398/publicationFile/30615/BSI-TR-03111_pdf.pdf
+         * 
+         * itu-t, ccitt(0) identified-organization(4) etsi(0) reserved(127) etsi-identified-organization(0) bsi-de(7)
+         */
+        public static readonly DerObjectIdentifier bsi_de = new DerObjectIdentifier("0.4.0.127.0.7");
+
+        /* 0.4.0.127.0.7.1.1 Root identifier for elliptic curve cryptography */
+        public static readonly DerObjectIdentifier id_ecc = bsi_de.Branch("1.1");
+
+        /* 0.4.0.127.0.7.1.1.4.1 */
+        public static readonly DerObjectIdentifier ecdsa_plain_signatures = id_ecc.Branch("4.1");
+    
+        /* 0.4.0.127.0.7.1.1.4.1.1 */
+        public static readonly DerObjectIdentifier ecdsa_plain_SHA1 = ecdsa_plain_signatures.Branch("1");
+
+        /* 0.4.0.127.0.7.1.1.4.1.2 */
+        public static readonly DerObjectIdentifier ecdsa_plain_SHA224 = ecdsa_plain_signatures.Branch("2");
+
+        /* 0.4.0.127.0.7.1.1.4.1.3 */
+        public static readonly DerObjectIdentifier ecdsa_plain_SHA256 = ecdsa_plain_signatures.Branch("3");
+
+        /* 0.4.0.127.0.7.1.1.4.1.4 */
+        public static readonly DerObjectIdentifier ecdsa_plain_SHA384 = ecdsa_plain_signatures.Branch("4");
+
+        /* 0.4.0.127.0.7.1.1.4.1.5 */
+        public static readonly DerObjectIdentifier ecdsa_plain_SHA512 = ecdsa_plain_signatures.Branch("5");
+
+        /* 0.4.0.127.0.7.1.1.4.1.6 */
+        public static readonly DerObjectIdentifier ecdsa_plain_RIPEMD160 = ecdsa_plain_signatures.Branch("6");
+    }
+}

--- a/crypto/src/crypto/signers/DsaDigestSigner.cs
+++ b/crypto/src/crypto/signers/DsaDigestSigner.cs
@@ -1,29 +1,29 @@
 using System;
-using System.Collections;
 using System.IO;
-using System.Text;
 
 using Org.BouncyCastle.Asn1;
-using Org.BouncyCastle.Crypto.Signers;
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Math;
 using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
-	public class DsaDigestSigner
+    public class DsaDigestSigner
 		: ISigner
 	{
 		private readonly IDigest digest;
 		private readonly IDsa dsaSigner;
 		private bool forSigning;
+        private bool useDerEncoding;
 
 		public DsaDigestSigner(
 			IDsa	signer,
-			IDigest	digest)
+			IDigest	digest,
+            bool useDerEncoding = true)
 		{
 			this.digest = digest;
 			this.dsaSigner = signer;
+            this.useDerEncoding = useDerEncoding;
 		}
 
 		public virtual string AlgorithmName
@@ -93,7 +93,7 @@ namespace Org.BouncyCastle.Crypto.Signers
 
 			BigInteger[] sig = dsaSigner.GenerateSignature(hash);
 
-			return DerEncode(sig[0], sig[1]);
+			return EncodeSignature(sig[0], sig[1]);
 		}
 
 		/// <returns>true if the internal state represents the signature described in the passed in array.</returns>
@@ -108,7 +108,7 @@ namespace Org.BouncyCastle.Crypto.Signers
 
 			try
 			{
-				BigInteger[] sig = DerDecode(signature);
+				BigInteger[] sig = DecodeSignature(signature);
 				return dsaSigner.VerifySignature(hash, sig[0], sig[1]);
 			}
 			catch (IOException)
@@ -123,7 +123,33 @@ namespace Org.BouncyCastle.Crypto.Signers
 			digest.Reset();
 		}
 
-		private byte[] DerEncode(
+        private byte[] EncodeSignature(
+            BigInteger r,
+            BigInteger s)
+        {
+            if (useDerEncoding)
+            {
+                return DerEncode(r, s);
+            } else
+            {
+                return PlainEncode(r, s);
+            }
+
+        }
+
+        private BigInteger[] DecodeSignature(byte[] rawSignature)
+        {
+            if (useDerEncoding)
+            {
+                return DerDecode(rawSignature);
+            } else
+            {
+                return PlainDecode(rawSignature);
+            }
+            
+        }
+
+        private byte[] DerEncode(
 			BigInteger	r,
 			BigInteger	s)
 		{
@@ -141,5 +167,34 @@ namespace Org.BouncyCastle.Crypto.Signers
 				((DerInteger) s[1]).Value
 			};
 		}
+
+        private byte[] PlainEncode(
+            BigInteger r,
+            BigInteger s)
+        {
+            var rBytes = r.ToByteArray();
+            var sBytes = s.ToByteArray();
+
+            var encodedSignature = new byte[rBytes.Length + sBytes.Length];
+            Array.Copy(rBytes, encodedSignature, rBytes.Length);
+            Array.Copy(sBytes, 0, encodedSignature, rBytes.Length, sBytes.Length);
+
+            return encodedSignature;
+        }
+
+        private BigInteger[] PlainDecode(
+            byte[] rawSignature)
+        {
+            var partLength = rawSignature.Length / 2;
+
+            // Add extra 0 in front to avoid negative numbers
+            var R = new byte[1 + partLength];
+            var S = new byte[1 + partLength];
+
+            Array.Copy(rawSignature, 0, R, 1, partLength);
+            Array.Copy(rawSignature, partLength, S, 1, partLength);
+
+            return new BigInteger[] { new BigInteger(R), new BigInteger(S) };
+        }
 	}
 }

--- a/crypto/src/security/SignerUtilities.cs
+++ b/crypto/src/security/SignerUtilities.cs
@@ -1,8 +1,8 @@
 using System;
 using System.Collections;
-using System.IO;
 
 using Org.BouncyCastle.Asn1;
+using Org.BouncyCastle.Asn1.Bsi;
 using Org.BouncyCastle.Asn1.CryptoPro;
 using Org.BouncyCastle.Asn1.Nist;
 using Org.BouncyCastle.Asn1.Oiw;
@@ -10,7 +10,6 @@ using Org.BouncyCastle.Asn1.Pkcs;
 using Org.BouncyCastle.Asn1.TeleTrust;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1.X9;
-using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Crypto.Digests;
 using Org.BouncyCastle.Crypto;
 using Org.BouncyCastle.Crypto.Engines;
@@ -221,6 +220,54 @@ namespace Org.BouncyCastle.Security
             algorithms["RIPEMD160WITHECDSA"] = "RIPEMD160withECDSA";
             algorithms[TeleTrusTObjectIdentifiers.ECSignWithRipeMD160.Id] = "RIPEMD160withECDSA";
 
+            algorithms["SHA1/ECDSAPlain"] = "ecdsa-plain-SHA1";
+            algorithms["SHA-1/ECDSAPlain"] = "ecdsa-plain-SHA1";
+            algorithms["ecdsaPlainWithSHA1"] = "ecdsa-plain-SHA1";
+            algorithms["ecdsaPlainWithSHA-1"] = "ecdsa-plain-SHA1";
+            algorithms["SHA1withECDSAPlain"] = "ecdsa-plain-SHA1";
+            algorithms["SHA-1withECDSAPlain"] = "ecdsa-plain-SHA1";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_SHA1.Id] = "ecdsa-plain-SHA1";
+
+            algorithms["SHA224/ECDSAPlain"] = "ecdsa-plain-SHA224";
+            algorithms["SHA-224/ECDSAPlain"] = "ecdsa-plain-SHA224";
+            algorithms["ecdsaPlainWithSHA224"] = "ecdsa-plain-SHA224";
+            algorithms["ecdsaPlainWithSHA-224"] = "ecdsa-plain-SHA224";
+            algorithms["SHA224withECDSAPlain"] = "ecdsa-plain-SHA224";
+            algorithms["SHA-224withECDSAPlain"] = "ecdsa-plain-SHA224";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_SHA224.Id] = "ecdsa-plain-SHA224";
+
+            algorithms["SHA256/ECDSAPlain"] = "ecdsa-plain-SHA256";
+            algorithms["SHA-256/ECDSAPlain"] = "ecdsa-plain-SHA256";
+            algorithms["ecdsaPlainWithSHA256"] = "ecdsa-plain-SHA256";
+            algorithms["ecdsaPlainWithSHA-256"] = "ecdsa-plain-SHA256";
+            algorithms["SHA256withECDSAPlain"] = "ecdsa-plain-SHA256";
+            algorithms["SHA-256withECDSAPlain"] = "ecdsa-plain-SHA256";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_SHA256.Id] = "ecdsa-plain-SHA256";
+
+            algorithms["SHA384/ECDSAPlain"] = "ecdsa-plain-SHA384";
+            algorithms["SHA-384/ECDSAPlain"] = "ecdsa-plain-SHA384";
+            algorithms["ecdsaPlainWithSHA384"] = "ecdsa-plain-SHA384";
+            algorithms["ecdsaPlainWithSHA-384"] = "ecdsa-plain-SHA384";
+            algorithms["SHA384withECDSAPlain"] = "ecdsa-plain-SHA384";
+            algorithms["SHA-384withECDSAPlain"] = "ecdsa-plain-SHA384";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_SHA384.Id] = "ecdsa-plain-SHA384";
+
+            algorithms["SHA512/ECDSAPlain"] = "ecdsa-plain-SHA512";
+            algorithms["SHA-512/ECDSAPlain"] = "ecdsa-plain-SHA512";
+            algorithms["ecdsaPlainWithSHA512"] = "ecdsa-plain-SHA512";
+            algorithms["ecdsaPlainWithSHA-512"] = "ecdsa-plain-SHA512";
+            algorithms["SHA512withECDSAPlain"] = "ecdsa-plain-SHA512";
+            algorithms["SHA-512withECDSAPlain"] = "ecdsa-plain-SHA512";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_SHA512.Id] = "ecdsa-plain-SHA512";
+
+            algorithms["RIPEMD160/ECDSAPlain"] = "ecdsa-plain-RIPEMD160";
+            algorithms["RIPEMD-160/ECDSAPlain"] = "ecdsa-plain-RIPEMD160";
+            algorithms["ecdsaPlainWithRIPEMD160"] = "ecdsa-plain-RIPEMD160";
+            algorithms["ecdsaPlainWithRIPEMD-160"] = "ecdsa-plain-RIPEMD160";
+            algorithms["RIPEMD160withECDSAPlain"] = "ecdsa-plain-RIPEMD160";
+            algorithms["RIPEMD-160withECDSAPlain"] = "ecdsa-plain-RIPEMD160";
+            algorithms[BsiObjectIdentifiers.ecdsa_plain_RIPEMD160.Id] = "ecdsa-plain-RIPEMD160";
+
             algorithms["GOST-3410"] = "GOST3410";
             algorithms["GOST-3410-94"] = "GOST3410";
             algorithms["GOST3411WITHGOST3410"] = "GOST3410";
@@ -261,6 +308,13 @@ namespace Org.BouncyCastle.Security
             oids["SHA-256withECDSA"] = X9ObjectIdentifiers.ECDsaWithSha256;
             oids["SHA-384withECDSA"] = X9ObjectIdentifiers.ECDsaWithSha384;
             oids["SHA-512withECDSA"] = X9ObjectIdentifiers.ECDsaWithSha512;
+
+            oids["ecdsa-plain-SHA1"] = BsiObjectIdentifiers.ecdsa_plain_SHA1;
+            oids["ecdsa-plain-SHA224"] = BsiObjectIdentifiers.ecdsa_plain_SHA224;
+            oids["ecdsa-plain-SHA256"] = BsiObjectIdentifiers.ecdsa_plain_SHA256;
+            oids["ecdsa-plain-SHA384"] = BsiObjectIdentifiers.ecdsa_plain_SHA384;
+            oids["ecdsa-plain-SHA512"] = BsiObjectIdentifiers.ecdsa_plain_SHA512;
+            oids["ecdsa-plain-RIPEMD160"] = BsiObjectIdentifiers.ecdsa_plain_RIPEMD160;
 
             oids["GOST3410"] = CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x94;
             oids["ECGOST3410"] = CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x2001;
@@ -495,6 +549,32 @@ namespace Org.BouncyCastle.Security
             if (mechanism.Equals("RIPEMD160withECDSA"))
             {
                 return (new DsaDigestSigner(new ECDsaSigner(), new RipeMD160Digest()));
+            }
+
+            if (mechanism.Equals("ecdsa-plain-SHA1"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new Sha1Digest(), false));
+            }
+            if (mechanism.Equals("ecdsa-plain-SHA224"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new Sha224Digest(), false));
+            }
+            if (mechanism.Equals("ecdsa-plain-SHA256"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new Sha256Digest(), false));
+            }
+            if (mechanism.Equals("ecdsa-plain-SHA384"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new Sha384Digest(), false));
+            }
+            if (mechanism.Equals("ecdsa-plain-512"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new Sha512Digest(), false));
+            }
+
+            if (mechanism.Equals("ecdsa-plain-RIPEMD160"))
+            {
+                return (new DsaDigestSigner(new ECDsaSigner(), new RipeMD160Digest(), false));
             }
 
             if (mechanism.Equals("SHA1WITHECNR"))


### PR DESCRIPTION
I've added support for the Plain ECDSA signature algorithms. The main difference for this is that the signatures for this are not DER encoded.
It's not a big difference, but wasn't supported yet and therefore I lost a lot of time to research for this.
Therefore, I've decided to share my work to improve the library :)

I tested it with verifying signatures. Also, because of the default value in the constructor parameters, existing code using the DsaDigestSigner will not break.

If there are any improvements I can make (or maybe did something wrong), I'm open to all feedback :)