### PR TITLE
Changed util classes from abstract to static

### DIFF
--- a/crypto/src/util/Arrays.cs
+++ b/crypto/src/util/Arrays.cs
@@ -6,7 +6,7 @@ using Org.BouncyCastle.Math;
 namespace Org.BouncyCastle.Utilities
 {
     /// <summary> General array utilities.</summary>
-    public abstract class Arrays
+    public static class Arrays
     {
         public static readonly byte[] EmptyBytes = new byte[0];
         public static readonly int[] EmptyInts = new int[0];

--- a/crypto/src/util/BigIntegers.cs
+++ b/crypto/src/util/BigIntegers.cs
@@ -8,7 +8,7 @@ namespace Org.BouncyCastle.Utilities
     /**
      * BigInteger utilities.
      */
-    public abstract class BigIntegers
+    public static class BigIntegers
     {
         private const int MaxIterations = 1000;
 

--- a/crypto/src/util/Enums.cs
+++ b/crypto/src/util/Enums.cs
@@ -10,7 +10,7 @@ using Org.BouncyCastle.Utilities.Date;
 
 namespace Org.BouncyCastle.Utilities
 {
-    internal abstract class Enums
+    internal static class Enums
     {
         internal static Enum GetEnumValue(System.Type enumType, string s)
         {

--- a/crypto/src/util/Integers.cs
+++ b/crypto/src/util/Integers.cs
@@ -2,7 +2,7 @@
 
 namespace Org.BouncyCastle.Utilities
 {
-    public abstract class Integers
+    public static class Integers
     {
         public static int RotateLeft(int i, int distance)
         {

--- a/crypto/src/util/Platform.cs
+++ b/crypto/src/util/Platform.cs
@@ -11,7 +11,7 @@ using System.Collections;
 
 namespace Org.BouncyCastle.Utilities
 {
-    internal abstract class Platform
+    internal static class Platform
     {
         private static readonly CompareInfo InvariantCompareInfo = CultureInfo.InvariantCulture.CompareInfo;
 

--- a/crypto/src/util/Strings.cs
+++ b/crypto/src/util/Strings.cs
@@ -4,7 +4,7 @@ using System.Text;
 namespace Org.BouncyCastle.Utilities
 {
     /// <summary> General string utilities.</summary>
-    public abstract class Strings
+    public static class Strings
     {
 
         public static string ToUpperCase(string original)

--- a/crypto/src/util/Times.cs
+++ b/crypto/src/util/Times.cs
@@ -2,7 +2,7 @@
 
 namespace Org.BouncyCastle.Utilities
 {
-    public sealed class Times
+    public static class Times
     {
         private static long NanosecondsPerTick = 100L;
 


### PR DESCRIPTION
A couple of classes in the Utilities namespace are abstract. They have no abstract methods, though, and only static methods. In the internal code, they are never instantiated or inherited.

Thus, the static qualifier is much more appropriate than the abstract qualifier. I changed this in this pull request.

I guess this would be a breaking change if someone used the code strangely, i.e. instantiated one of those classes. I see no reason why someone would do that, though.