### PR TITLE
Remove the digest from OID for the digestEncryptionAlgorithm

### DIFF
--- a/crypto/src/cms/CMSSignedDataGenerator.cs
+++ b/crypto/src/cms/CMSSignedDataGenerator.cs
@@ -88,7 +88,8 @@ namespace Org.BouncyCastle.Cms
                 this.sigCalc = sigCalc;
                 this.signerIdentifier = signerIdentifier;
                 this.digestOID = new DefaultDigestAlgorithmIdentifierFinder().find((AlgorithmIdentifier)sigCalc.AlgorithmDetails).Algorithm.Id;
-                this.encOID = ((AlgorithmIdentifier)sigCalc.AlgorithmDetails).Algorithm.Id;
+                this.encOID = Helper.FindEncryptionAlgOID((AlgorithmIdentifier)sigCalc.AlgorithmDetails);
+                
                 this.sAttr = sAttr;
                 this.unsAttr = unsAttr;
                 this.baseSignedTable = baseSignedTable;

--- a/crypto/src/cms/CMSSignedHelper.cs
+++ b/crypto/src/cms/CMSSignedHelper.cs
@@ -127,7 +127,16 @@ namespace Org.BouncyCastle.Cms
             ecAlgorithms.Add(CmsSignedGenerator.DigestSha512, EncryptionECDsaWithSha512);
     }
 
-		/**
+        internal string FindEncryptionAlgOID(AlgorithmIdentifier algorithmDetails)
+        {
+            string algName = (string)encryptionAlgs[algorithmDetails.Algorithm.Id];
+            if ("RSA" == algName)
+                return CmsSignedGenerator.EncryptionRsa;    /* this strips off the digest algorithm */
+            else
+                return algorithmDetails.Algorithm.Id;
+        }
+
+        /**
         * Return the digest algorithm using one of the standard JCA string
         * representations rather than the algorithm identifier (if possible).
         */


### PR DESCRIPTION
The CMSSignedDataGenerator allows adding signers in two ways. One are the methods ```AddSigner```, which work for me, while the other ```AddSignerInfoGenerator``` adds the wrong OID for the signature algorithm to the PKCS#7. In my case, it adds sha256WithRSAEncryption (1 2 840 113549 1 1 11), where other common CMS signed data files I have looked at contain only rsaEncryption (1 2 840 113549 1 1 1).

As per [RFC 2315, Section 9.2](https://tools.ietf.org/html/rfc2315#section-9.2), the "digestEncryptionAlgorithm identifies the digest-encryption algorithm (and any associated parameters) under which the message digest and associated information are encrypted with the signer's private key." I understand this also to say that the digest should not be part of the OID.

With this fix, the correct OID appears in the CMS, and I can use the CMS with other crypto libraries, too.

It would be very kind if a maintainer could review this change.