### PR TITLE
Update TlsProtocol.cs

### DIFF
--- a/crypto/src/crypto/tls/TlsProtocol.cs
+++ b/crypto/src/crypto/tls/TlsProtocol.cs
@@ -748,12 +748,17 @@ namespace Org.BouncyCastle.Crypto.Tls
          */
         public virtual void OfferInput(byte[] input)
         {
+            this.OfferInput(input, 0, input.Length);
+        }
+        
+        public virtual void OfferInput(byte[] input, int offset, int length)
+        {
             if (mBlocking)
                 throw new InvalidOperationException("Cannot use OfferInput() in blocking mode! Use Stream instead.");
             if (mClosed)
                 throw new IOException("Connection is closed, cannot accept any more input");
 
-            mInputBuffers.Write(input);
+            mInputBuffers.Write(input, offset, length);
 
             // loop while there are enough bytes to read the length of the next record
             while (mInputBuffers.Available >= RecordStream.TLS_HEADER_SIZE)


### PR DESCRIPTION
added `TlsProtocol.OfferInput()` overload which specify _offset_ and _length_ of input buffer like in java source https://www.bouncycastle.org/docs/tlsdocs1.5on/org/bouncycastle/tls/TlsProtocol.html