### PR TITLE
Fixes case in DTLS handshake where throwing a TlsFatalAlert exception gets silently swallowed

### DIFF
--- a/crypto/src/crypto/tls/DtlsReliableHandshake.cs
+++ b/crypto/src/crypto/tls/DtlsReliableHandshake.cs
@@ -117,7 +117,7 @@ namespace Org.BouncyCastle.Crypto.Tls
                         }
                     }
                 }
-                catch (IOException)
+                catch (IOException e) when (!(e is TlsFatalAlert))
                 {
                     // NOTE: Assume this is a timeout for the moment
                 }


### PR DESCRIPTION
The loop running the DTLS handshake logic swallows `IOExceptions` on the premise that they are network timeouts. A problem occurs if a handshake fails (in my case due to `ssl_error_no_cypher_overlap`) and a `TlsFatalAlert` exception is thrown. Because it derives from `TlsException : IOException` it also gets silently swallowed and the DTLS handshake logic attempts to send the outstanding record forever.

This PR adds an exception for `TlsFatalAlerts` to inform the application the DTLS handshake has failed.