### PR TITLE
Added signing with extended key for Ed25519

### DIFF
--- a/crypto/src/math/ec/rfc8032/Ed25519.cs
+++ b/crypto/src/math/ec/rfc8032/Ed25519.cs
@@ -1100,6 +1100,21 @@ namespace Org.BouncyCastle.Math.EC.Rfc8032
             ImplSign(sk, skOff, pk, pkOff, ctx, phflag, m, 0, m.Length, sig, sigOff);
         }
 
+        public static void SignByExtendedKey(byte[] h, byte[] ctx, byte[] m, int mOff, int mLen, byte[] sig, int sigOff)
+        {
+            byte phflag = 0x00;
+
+            byte[] s = new byte[ScalarBytes];
+            PruneScalar(h, 0, s);
+
+            byte[] pk = new byte[PointBytes];
+            ScalarMultBaseEncoded(s, pk, 0);
+
+            IDigest d = CreateDigest();
+
+            ImplSign(d, h, s, pk, 0, ctx, phflag, m, mOff, mLen, sig, sigOff);
+        }
+
         public static bool Verify(byte[] sig, int sigOff, byte[] pk, int pkOff, byte[] m, int mOff, int mLen)
         {
             byte[] ctx = null;


### PR DESCRIPTION
There are algorithms for hierarchical deterministic key generation for the Ed22219 curve (e.g. [BIP32-Ed25519](https://ieeexplore.ieee.org/document/7966967)).

These algorithms use extended keys, which are obtained at the first step after calculation the digest SHA-512 function from the secret key.

A bit of terminology:
- **sk**: 32-bytes secret key;
- **sk_expanded**: 64-bytes key, the first [0..31] bytes of which are equal to the secret key and the second half [32..63] contains public key
- **sk_extended**: 64-bytes key which is calculated in the first step of the singning as `SHA512(sk)`.

In the `ImplSign` functions the obtained value of the extended key is stored in the `h` variable.

Unfortunately, the current public signing API only allows working with the regular 32-bytes secret keys from which the extended key is further calculated.

It would be great to add another entry point accepting the Extended key `h`.
