### PR TITLE
DTLS fixes

### DIFF
--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -473,15 +473,15 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.macBlock = new byte[macSize];
             Array.Copy(tag, 0, macBlock, 0, macSize);
 
-            if (forEncryption)
+            try
             {
-                // Append T to the message
-                Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
-                resultLen += macSize;
-            }
-            else
-            {
-                try
+                if (forEncryption)
+                {
+                    // Append T to the message
+                    Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
+                    resultLen += macSize;
+                }
+                else
                 {
                     // Retrieve the T value from the message and compare to calculated one
                     byte[] msgMac = new byte[macSize];
@@ -489,10 +489,10 @@ namespace Org.BouncyCastle.Crypto.Modes
                     if (!Arrays.ConstantTimeAreEqual(this.macBlock, msgMac))
                         throw new InvalidCipherTextException("mac check in GCM failed");
                 }
-                finally
-                {
-                    Reset(false);
-                }
+            }
+            finally
+            {
+                Reset(false);
             }
 
             return resultLen;

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -473,22 +473,27 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.macBlock = new byte[macSize];
             Array.Copy(tag, 0, macBlock, 0, macSize);
 
-            if (forEncryption)
+            try
             {
-                // Append T to the message
-                Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
-                resultLen += macSize;
+                if (forEncryption)
+                {
+                    // Append T to the message
+                    Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
+                    resultLen += macSize;
+                }
+                else
+                {
+                    // Retrieve the T value from the message and compare to calculated one
+                    byte[] msgMac = new byte[macSize];
+                    Array.Copy(bufBlock, extra, msgMac, 0, macSize);
+                    if (!Arrays.ConstantTimeAreEqual(this.macBlock, msgMac))
+                        throw new InvalidCipherTextException("mac check in GCM failed");
+                }
             }
-            else
+            finally
             {
-                // Retrieve the T value from the message and compare to calculated one
-                byte[] msgMac = new byte[macSize];
-                Array.Copy(bufBlock, extra, msgMac, 0, macSize);
-                if (!Arrays.ConstantTimeAreEqual(this.macBlock, msgMac))
-                    throw new InvalidCipherTextException("mac check in GCM failed");
+                Reset(false);
             }
-
-            Reset(false);
 
             return resultLen;
         }

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -473,15 +473,15 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.macBlock = new byte[macSize];
             Array.Copy(tag, 0, macBlock, 0, macSize);
 
-            try
+            if (forEncryption)
             {
-                if (forEncryption)
-                {
-                    // Append T to the message
-                    Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
-                    resultLen += macSize;
-                }
-                else
+                // Append T to the message
+                Array.Copy(macBlock, 0, output, outOff + bufOff, macSize);
+                resultLen += macSize;
+            }
+            else
+            {
+                try
                 {
                     // Retrieve the T value from the message and compare to calculated one
                     byte[] msgMac = new byte[macSize];
@@ -489,10 +489,10 @@ namespace Org.BouncyCastle.Crypto.Modes
                     if (!Arrays.ConstantTimeAreEqual(this.macBlock, msgMac))
                         throw new InvalidCipherTextException("mac check in GCM failed");
                 }
-            }
-            finally
-            {
-                Reset(false);
+                finally
+                {
+                    Reset(false);
+                }
             }
 
             return resultLen;

--- a/crypto/src/crypto/tls/DtlsRecordLayer.cs
+++ b/crypto/src/crypto/tls/DtlsRecordLayer.cs
@@ -164,7 +164,7 @@ namespace Org.BouncyCastle.Crypto.Tls
                     mRetransmitTimeout = null;
                 }
 
-                int receiveLimit = System.Math.Min(len, GetReceiveLimit()) + RECORD_HEADER_LENGTH;
+                int receiveLimit = mTransport.GetReceiveLimit();
                 if (record == null || record.Length < receiveLimit)
                 {
                     record = new byte[receiveLimit];

--- a/crypto/src/crypto/tls/DtlsTransport.cs
+++ b/crypto/src/crypto/tls/DtlsTransport.cs
@@ -41,8 +41,16 @@ namespace Org.BouncyCastle.Crypto.Tls
             }
             catch (TlsFatalAlert fatalAlert)
             {
-                mRecordLayer.Fail(fatalAlert.AlertDescription);
-                throw fatalAlert;
+                if (fatalAlert.AlertDescription == AlertDescription.bad_record_mac)
+                {
+                    // DTLS can ignore corrupt records
+                    return -1;
+                }
+                else
+                {
+                    mRecordLayer.Fail(fatalAlert.AlertDescription);
+                    throw fatalAlert;
+                }
             }
             //catch (InterruptedIOException e)
             //{


### PR DESCRIPTION
* Change the size of the `record` buffer in `DtlsRecordLayer.Receive` to be able to hold the actual record. Before, it was sized to fit the decrypted plaintext plus the header, whereas the ciphertext is what's actually sent over the underlying transport.
* `Reset` the `GCMBlockCipher` even when the MAC is invalid, because DTLS needs to be able to decrypt each record independently. Without the reset, corrupt packets can cause the `GCMBlockCipher` object to enter a state in which it will fail to decrypt all subsequent records.
* Ignore `bad_record_mac` "fatal" errors in `DtlsTransport.Receive`, because DTLS is meant to be able to ignore corrupt records.