### PR TITLE
Esia sign and verify sign support

### DIFF
--- a/crypto/src/cms/CMSSignedHelper.cs
+++ b/crypto/src/cms/CMSSignedHelper.cs
@@ -90,6 +90,8 @@ namespace Org.BouncyCastle.Cms
 			encryptionAlgs.Add(CmsSignedGenerator.EncryptionRsaPss, "RSAandMGF1");
 			encryptionAlgs.Add(CryptoProObjectIdentifiers.GostR3410x94.Id, "GOST3410");
 			encryptionAlgs.Add(CryptoProObjectIdentifiers.GostR3410x2001.Id, "ECGOST3410");
+			encryptionAlgs.Add(Asn1.Rosstandart.RosstandartObjectIdentifiers.id_tc26_gost_3410_12_256.Id, "ECGOST3410");
+			encryptionAlgs.Add(Asn1.Rosstandart.RosstandartObjectIdentifiers.id_tc26_gost_3410_12_512.Id, "ECGOST3410");
 			encryptionAlgs.Add("1.3.6.1.4.1.5849.1.6.2", "ECGOST3410");
 			encryptionAlgs.Add("1.3.6.1.4.1.5849.1.1.5", "GOST3410");
 
@@ -105,6 +107,8 @@ namespace Org.BouncyCastle.Cms
 			digestAlgs.Add(TeleTrusTObjectIdentifiers.RipeMD160.Id, "RIPEMD160");
 			digestAlgs.Add(TeleTrusTObjectIdentifiers.RipeMD256.Id, "RIPEMD256");
 			digestAlgs.Add(CryptoProObjectIdentifiers.GostR3411.Id,  "GOST3411");
+			digestAlgs.Add(Asn1.Rosstandart.RosstandartObjectIdentifiers.id_tc26_gost_3411_12_256.Id, "GOST3411-2012-256");
+			digestAlgs.Add(Asn1.Rosstandart.RosstandartObjectIdentifiers.id_tc26_gost_3411_12_512.Id, "GOST3411-2012-512");
 			digestAlgs.Add("1.3.6.1.4.1.5849.1.2.1",  "GOST3411");
 
 			digestAliases.Add("SHA1", new string[] { "SHA-1" });

--- a/crypto/src/crypto/operators/Asn1Signature.cs
+++ b/crypto/src/crypto/operators/Asn1Signature.cs
@@ -7,6 +7,7 @@ using Org.BouncyCastle.Asn1.CryptoPro;
 using Org.BouncyCastle.Asn1.Nist;
 using Org.BouncyCastle.Asn1.Oiw;
 using Org.BouncyCastle.Asn1.Pkcs;
+using Org.BouncyCastle.Asn1.Rosstandart;
 using Org.BouncyCastle.Asn1.TeleTrust;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1.X9;
@@ -71,6 +72,9 @@ namespace Org.BouncyCastle.Crypto.Operators
 			algorithms.Add("GOST3411WITHECGOST3410", CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x2001);
 			algorithms.Add("GOST3411WITHECGOST3410-2001", CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x2001);
 			algorithms.Add("GOST3411WITHGOST3410-2001", CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x2001);
+
+			algorithms.Add("GOST3411-2012-256WITHECGOST3410", RosstandartObjectIdentifiers.id_tc26_signwithdigest_gost_3410_12_256);
+			algorithms.Add("GOST3411-2012-512WITHECGOST3410", RosstandartObjectIdentifiers.id_tc26_signwithdigest_gost_3410_12_512);
 
 			//
 			// According to RFC 3279, the ASN.1 encoding SHALL (id-dsa-with-sha1) or MUST (ecdsa-with-SHA*) omit the parameters field.

--- a/crypto/src/security/SignerUtilities.cs
+++ b/crypto/src/security/SignerUtilities.cs
@@ -336,6 +336,8 @@ namespace Org.BouncyCastle.Security
             algorithms["ECGOST-3410-2001"] = "ECGOST3410";
             algorithms["GOST3411WITHECGOST3410"] = "ECGOST3410";
             algorithms[CryptoProObjectIdentifiers.GostR3411x94WithGostR3410x2001.Id] = "ECGOST3410";
+            algorithms["GOST3411-2012-256WITHECGOST3410"] = "GOST3411-2012-256withECGOST3410";
+            algorithms["GOST3411-2012-512WITHECGOST3410"] = "GOST3411-2012-512withECGOST3410";
 
             algorithms["ED25519"] = "Ed25519";
             algorithms[EdECObjectIdentifiers.id_Ed25519.Id] = "Ed25519";
@@ -593,6 +595,14 @@ namespace Org.BouncyCastle.Security
             if (mechanism.Equals("ECGOST3410"))
             {
                 return new Gost3410DigestSigner(new ECGost3410Signer(), new Gost3411Digest());
+            }
+            if (mechanism.Equals("GOST3411-2012-256withECGOST3410"))
+            {
+                return new Gost3410DigestSigner(new ECGost3410Signer(), new Gost3411_2012_256Digest());
+            }
+            if (mechanism.Equals("GOST3411-2012-512withECGOST3410"))
+            {
+                return new Gost3410DigestSigner(new ECGost3410Signer(), new Gost3411_2012_512Digest());
             }
 
             if (mechanism.Equals("SHA1WITHRSA/ISO9796-2"))


### PR DESCRIPTION
Greetings, developers!
A new mapping is required to create and verify a ESIA (https://www.gosuslugi.ru/) signature for oauth2.
Hashing algorithm - GOST 34.11-2012
Algorithm electronically - GOST 34.10-2012

More information https://partners.gosuslugi.ru/catalog/esia

I ask you to add it.
Best regards, Kozlov Gleb.