### PR TITLE
Fix issue where not providing a TSA policy OID throws a null reference exception

### DIFF
--- a/crypto/src/tsp/TimeStampTokenGenerator.cs
+++ b/crypto/src/tsp/TimeStampTokenGenerator.cs
@@ -68,7 +68,7 @@ namespace Org.BouncyCastle.Tsp
 
             this.signerInfoGenerator = signerInfoGen;
             this.digestCalculator = digestCalculator;
-            this.tsaPolicyOID = tsaPolicy.Id;
+            this.tsaPolicyOID = tsaPolicy != null ? tsaPolicy.Id : null;
 
             if (signerInfoGenerator.certificate == null)
             {
@@ -140,10 +140,6 @@ namespace Org.BouncyCastle.Tsp
                Asn1DigestFactory.Get(OiwObjectIdentifiers.IdSha1),
                tsaPolicyOID != null?new DerObjectIdentifier(tsaPolicyOID):null, false)
         {
-
-            this.tsaPolicyOID = tsaPolicyOID;
-
-        
         }
 
 


### PR DESCRIPTION
The TSA policy ID is optional per RFC 3161. If you try to generate a timestamp token with a null TSA policy ID, the TimeStampTokenGenerator throws a NullReferenceException.

Fixes #295 