### PR TITLE
Missing OtherRevocationInfoFormat in CMSSigned classes

### DIFF
--- a/crypto/src/cms/CMSSignedData.cs
+++ b/crypto/src/cms/CMSSignedData.cs
@@ -248,7 +248,20 @@ namespace Org.BouncyCastle.Cms
 
 			return crlStore;
 		}
+		
+		/// <summary>
+		/// Return X509Store containing OtherRevocationInfoFormat.Info Asn1Encodable
+		/// </summary>
+		/// <param name="otherRevocationInfoFormatIdentifier"></param>
+		/// <returns></returns>
+		public IX509Store GetOtherRevocationInfo(
+			DerObjectIdentifier otherRevocationInfoFormatIdentifier)
+		{
+			var otherRevocationInfoStore =  Helper.CreateOtherRevocationInfoStore(otherRevocationInfoFormatIdentifier, signedData.CRLs);
 
+			return otherRevocationInfoStore;
+		}
+		
 		[Obsolete("Use 'SignedContentType' property instead.")]
 		public string SignedContentTypeOid
 		{

--- a/crypto/src/cms/CMSSignedDataParser.cs
+++ b/crypto/src/cms/CMSSignedDataParser.cs
@@ -72,7 +72,7 @@ namespace Org.BouncyCastle.Cms
 		private IX509Store				_attributeStore;
 		private IX509Store				_certificateStore;
 		private IX509Store				_crlStore;
-
+		
 		public CmsSignedDataParser(
 			byte[] sigBlock)
 			: this(new MemoryStream(sigBlock, false))
@@ -277,7 +277,7 @@ namespace Org.BouncyCastle.Cms
 
 			return _certificateStore;
 		}
-
+	
 		/**
 		* return a X509Store containing CRLs, if any, contained
 		* in this message.
@@ -298,6 +298,24 @@ namespace Org.BouncyCastle.Cms
 			}
 
 			return _crlStore;
+		}
+		
+		/// <summary>
+		/// Return X509Store containing OtherRevocationInfoFormat.Info Asn1Encodable
+		/// </summary>
+		/// <param name="otherRevocationInfoFormatIdentifier"></param>
+		/// <returns></returns>
+		public IX509Store GetOtherRevocationInfo(
+			DerObjectIdentifier otherRevocationInfoFormatIdentifier)
+		{
+			if (_crlSet == null)
+			{
+				PopulateCertCrlSets();
+			}
+			
+			var otherRevocationInfoStore =  Helper.CreateOtherRevocationInfoStore(otherRevocationInfoFormatIdentifier, _crlSet);
+
+			return otherRevocationInfoStore;
 		}
 
 		private void PopulateCertCrlSets()

--- a/crypto/src/cms/CMSSignedGenerator.cs
+++ b/crypto/src/cms/CMSSignedGenerator.cs
@@ -1,7 +1,5 @@
 using System;
 using System.Collections;
-using System.IO;
-
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.BC;
 using Org.BouncyCastle.Asn1.Bsi;
@@ -16,8 +14,6 @@ using Org.BouncyCastle.Asn1.Rosstandart;
 using Org.BouncyCastle.Asn1.TeleTrust;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Asn1.X9;
-using Org.BouncyCastle.Crypto;
-using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
 using Org.BouncyCastle.Utilities;
 using Org.BouncyCastle.Utilities.Collections;
@@ -572,6 +568,34 @@ namespace Org.BouncyCastle.Cms
             IX509Store crlStore)
         {
             CollectionUtilities.AddRange(_crls, CmsUtilities.GetCrlsFromStore(crlStore));
+        }
+
+        /**
+     * Add a single instance of otherRevocationData to the CRL set to be included with the generated SignedData message.
+     *
+     * @param otherRevocationInfoFormat the OID specifying the format of the otherRevocationInfo data.
+     * @param otherRevocationInfo the otherRevocationInfo ASN.1 structure.
+     */
+        public void AddOtherRevocationInfo(
+            DerObjectIdentifier otherRevocationInfoFormatIdentifier,
+            Asn1Encodable otherRevocationInfo)
+        {
+            var otherRevocationInfoFormat = new OtherRevocationInfoFormat(otherRevocationInfoFormatIdentifier, otherRevocationInfo);
+            CmsUtilities.ValidateOcspResponseInfoFormat(otherRevocationInfoFormat);
+            _crls.Add(Asn1TaggedObject.GetInstance(new DerTaggedObject(false, 1, new OtherRevocationInfoFormat(otherRevocationInfoFormatIdentifier, otherRevocationInfo))));
+        }
+
+        /**
+     * Add a Store of otherRevocationData to the CRL set to be included with the generated SignedData message.
+     *
+     * @param otherRevocationInfoFormat the OID specifying the format of the otherRevocationInfo data.
+     * @param otherRevocationInfos a Store of otherRevocationInfo data to add.
+     */
+        public void AddOtherRevocationInfo(
+            DerObjectIdentifier otherRevocationInfoFormatIdentifier,
+            IX509Store otherRevocationInfos)
+        {
+            CollectionUtilities.AddRange(_crls, CmsUtilities.GetOtherRevocationInfoFromStore(otherRevocationInfoFormatIdentifier, otherRevocationInfos));
         }
 
         /**

--- a/crypto/src/x509/store/X509StoreFactory.cs
+++ b/crypto/src/x509/store/X509StoreFactory.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Collections;
-
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.X509.Store
@@ -43,6 +43,10 @@ namespace Org.BouncyCastle.X509.Store
 				case "CRL":
 					checkCorrectType(coll, typeof(X509Crl));
 					break;
+				case "OTHERREVOCATIONINFO":
+					checkCorrectType(coll, typeof(Asn1Encodable));
+					break;
+
 				default:
 					throw new NoSuchStoreException("X.509 store type '" + type + "' not available.");
 			}

--- a/crypto/test/src/cms/test/CMSTestUtil.cs
+++ b/crypto/test/src/cms/test/CMSTestUtil.cs
@@ -2,7 +2,7 @@ using System;
 using System.Collections;
 using System.IO;
 using System.Text;
-
+using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.CryptoPro;
 using Org.BouncyCastle.Asn1.X509;
 using Org.BouncyCastle.Crypto;
@@ -483,6 +483,16 @@ namespace Org.BouncyCastle.Cms.Tests
             }
 
             return X509StoreFactory.Create("CRL/Collection", new X509CollectionStoreParameters(crlList));
+        }
+
+        internal static IX509Store MakeOtherRevocationInfoStore(byte[] ocspResponseBytes)
+        {
+	        IList OtherRevocationInfoList = new ArrayList(); 
+
+	        // Prepare ocsp response
+	        OtherRevocationInfoList.Add(Asn1Object.FromByteArray(ocspResponseBytes));
+	        
+	        return  X509StoreFactory.Create("OTHERREVOCATIONINFO/COLLECTION", new X509CollectionStoreParameters(OtherRevocationInfoList));
         }
 
         private static AuthorityKeyIdentifier CreateAuthorityKeyId(

--- a/crypto/test/src/cms/test/SignedDataStreamTest.cs
+++ b/crypto/test/src/cms/test/SignedDataStreamTest.cs
@@ -42,6 +42,40 @@ namespace Org.BouncyCastle.Cms.Tests
 		private static X509Crl signCrl;
 		private static X509Crl origCrl;
 
+		private static byte[] _ocspResponseBytes = Base64.Decode(
+			"MIIFnAoBAKCCBZUwggWRBgkrBgEFBQcwAQEEggWCMIIFfjCCARehgZ8wgZwx"
+			+ "CzAJBgNVBAYTAklOMRcwFQYDVQQIEw5BbmRocmEgcHJhZGVzaDESMBAGA1UE"
+			+ "BxMJSHlkZXJhYmFkMQwwCgYDVQQKEwNUQ1MxDDAKBgNVBAsTA0FUQzEeMBwG"
+			+ "A1UEAxMVVENTLUNBIE9DU1AgUmVzcG9uZGVyMSQwIgYJKoZIhvcNAQkBFhVv"
+			+ "Y3NwQHRjcy1jYS50Y3MuY28uaW4YDzIwMDMwNDAyMTIzNDU4WjBiMGAwOjAJ"
+			+ "BgUrDgMCGgUABBRs07IuoCWNmcEl1oHwIak1BPnX8QQUtGyl/iL9WJ1VxjxF"
+			+ "j0hAwJ/s1AcCAQKhERgPMjAwMjA4MjkwNzA5MjZaGA8yMDAzMDQwMjEyMzQ1"
+			+ "OFowDQYJKoZIhvcNAQEFBQADgYEAfbN0TCRFKdhsmvOdUoiJ+qvygGBzDxD/"
+			+ "VWhXYA+16AphHLIWNABR3CgHB3zWtdy2j7DJmQ/R7qKj7dUhWLSqclAiPgFt"
+			+ "QQ1YvSJAYfEIdyHkxv4NP0LSogxrumANcDyC9yt/W9yHjD2ICPBIqCsZLuLk"
+			+ "OHYi5DlwWe9Zm9VFwCGgggPMMIIDyDCCA8QwggKsoAMCAQICAQYwDQYJKoZI"
+			+ "hvcNAQEFBQAwgZQxFDASBgNVBAMTC1RDUy1DQSBPQ1NQMSYwJAYJKoZIhvcN"
+			+ "AQkBFhd0Y3MtY2FAdGNzLWNhLnRjcy5jby5pbjEMMAoGA1UEChMDVENTMQww"
+			+ "CgYDVQQLEwNBVEMxEjAQBgNVBAcTCUh5ZGVyYWJhZDEXMBUGA1UECBMOQW5k"
+			+ "aHJhIHByYWRlc2gxCzAJBgNVBAYTAklOMB4XDTAyMDgyOTA3MTE0M1oXDTAz"
+			+ "MDgyOTA3MTE0M1owgZwxCzAJBgNVBAYTAklOMRcwFQYDVQQIEw5BbmRocmEg"
+			+ "cHJhZGVzaDESMBAGA1UEBxMJSHlkZXJhYmFkMQwwCgYDVQQKEwNUQ1MxDDAK"
+			+ "BgNVBAsTA0FUQzEeMBwGA1UEAxMVVENTLUNBIE9DU1AgUmVzcG9uZGVyMSQw"
+			+ "IgYJKoZIhvcNAQkBFhVvY3NwQHRjcy1jYS50Y3MuY28uaW4wgZ8wDQYJKoZI"
+			+ "hvcNAQEBBQADgY0AMIGJAoGBAM+XWW4caMRv46D7L6Bv8iwtKgmQu0SAybmF"
+			+ "RJiz12qXzdvTLt8C75OdgmUomxp0+gW/4XlTPUqOMQWv463aZRv9Ust4f8MH"
+			+ "EJh4ekP/NS9+d8vEO3P40ntQkmSMcFmtA9E1koUtQ3MSJlcs441JjbgUaVnm"
+			+ "jDmmniQnZY4bU3tVAgMBAAGjgZowgZcwDAYDVR0TAQH/BAIwADALBgNVHQ8E"
+			+ "BAMCB4AwEwYDVR0lBAwwCgYIKwYBBQUHAwkwNgYIKwYBBQUHAQEEKjAoMCYG"
+			+ "CCsGAQUFBzABhhpodHRwOi8vMTcyLjE5LjQwLjExMDo3NzAwLzAtBgNVHR8E"
+			+ "JjAkMCKgIKAehhxodHRwOi8vMTcyLjE5LjQwLjExMC9jcmwuY3JsMA0GCSqG"
+			+ "SIb3DQEBBQUAA4IBAQB6FovM3B4VDDZ15o12gnADZsIk9fTAczLlcrmXLNN4"
+			+ "PgmqgnwF0Ymj3bD5SavDOXxbA65AZJ7rBNAguLUo+xVkgxmoBH7R2sBxjTCc"
+			+ "r07NEadxM3HQkt0aX5XYEl8eRoifwqYAI9h0ziZfTNes8elNfb3DoPPjqq6V"
+			+ "mMg0f0iMS4W8LjNPorjRB+kIosa1deAGPhq0eJ8yr0/s2QR2/WFD5P4aXc8I"
+			+ "KWleklnIImS3zqiPrq6tl2Bm8DZj7vXlTOwmraSQxUwzCKwYob1yGvNOUQTq"
+			+ "pG6jxn7jgDawHU1+WjWQe4Q34/pWeGLysxTraMa+Ug9kPe+jy/qRX2xwvKBZ");
+		
 		private static AsymmetricCipherKeyPair SignKP
 		{
 			get { return signKP == null ? (signKP = CmsTestUtil.MakeKeyPair()) : signKP; }
@@ -344,8 +378,77 @@ namespace Org.BouncyCastle.Cms.Tests
 			Assert.IsTrue(col.Contains(SignCrl));
 			Assert.IsTrue(col.Contains(OrigCrl));
 		}
-
+		
 		[Test]
+        public void TestCrlAndOtherRevocationInfoFormat()
+        {
+            MemoryStream bOut = new MemoryStream();
+
+            IX509Store x509Certs = CmsTestUtil.MakeCertStore(OrigCert, SignCert);
+            IX509Store x509Crls = CmsTestUtil.MakeCrlStore(SignCrl, OrigCrl);
+            IX509Store x509OtherRevocationInfo = CmsTestUtil.MakeOtherRevocationInfoStore(_ocspResponseBytes);
+            
+            CmsSignedDataStreamGenerator gen = new CmsSignedDataStreamGenerator();
+            gen.AddSigner(OrigKP.Private, OrigCert, CmsSignedDataStreamGenerator.DigestSha1);
+            gen.AddCertificates(x509Certs);
+            gen.AddCrls(x509Crls);
+            gen.AddOtherRevocationInfo(CmsObjectIdentifiers.id_ri_ocsp_response, x509OtherRevocationInfo);
+
+            Stream sigOut = gen.Open(bOut);
+
+            byte[] testBytes = Encoding.ASCII.GetBytes(TestMessage);
+            sigOut.Write(testBytes, 0, testBytes.Length);
+
+            sigOut.Close();
+
+            CheckSigParseable(bOut.ToArray());
+
+            CmsSignedDataParser sp = new CmsSignedDataParser(
+                new CmsTypedStream(new MemoryStream(testBytes, false)), bOut.ToArray());
+
+            sp.GetSignedContent().Drain();
+
+            // compute expected content digest
+            byte[] hash = DigestUtilities.CalculateDigest("SHA1", testBytes);
+
+            VerifySignatures(sp, hash);
+
+            //
+            // try using existing signer
+            //
+            gen = new CmsSignedDataStreamGenerator();
+            gen.AddSigners(sp.GetSignerInfos());
+            gen.AddCertificates(sp.GetCertificates("Collection"));
+            gen.AddCrls(sp.GetCrls("Collection"));
+            var spOtherRevocationInfo = sp.GetOtherRevocationInfo(CmsObjectIdentifiers.id_ri_ocsp_response);
+            gen.AddOtherRevocationInfo(CmsObjectIdentifiers.id_ri_ocsp_response, spOtherRevocationInfo);
+
+            bOut.SetLength(0);
+
+            sigOut = gen.Open(bOut, true);
+            sigOut.Write(testBytes, 0, testBytes.Length);
+            sigOut.Close();
+
+            VerifyEncodedData(bOut);
+
+            //
+            // look for the CRLs
+            //
+            ArrayList crls = new ArrayList(x509Crls.GetMatches(null));
+            
+            Assert.AreEqual(2, crls.Count);
+            Assert.IsTrue(crls.Contains(SignCrl));
+            Assert.IsTrue(crls.Contains(OrigCrl));
+            
+            //
+            // look for OtherRevocationInfo
+            //
+            ArrayList otherRevocationInfos = new ArrayList(x509OtherRevocationInfo.GetMatches(null));
+            Assert.AreEqual(1, otherRevocationInfos.Count);
+            Assert.AreEqual(1, spOtherRevocationInfo.GetMatches(null).Count);
+        }
+
+        [Test]
 		public void TestSha1WithRsaNonData()
 		{
 			MemoryStream bOut = new MemoryStream();


### PR DESCRIPTION
This PR aims to add support to OtherRevocationInfoFormat in CMSSigned* classes.
The implementation is inspired from Java repo.

I recently had to deal with CAdES-LT baseline and I realized that CrlSet can either contain X509Crl and OtherRevocationInfoFormat objects.
Unfortunately the current bc-csharp doesn't manage this aspect and breaks throwing an InvalidCastException in the CreateCrlStore method if crlSet contains OtherRevocationInfoFormat.

I also added the test method TestCrlAndOtherRevocationInfoFormat in order to verify the correctness of the solution.