### PR TITLE
csproj: fix file name casing

### DIFF
--- a/crypto/BouncyCastle.Android.csproj
+++ b/crypto/BouncyCastle.Android.csproj
@@ -737,7 +737,7 @@
     <Compile Include="src\crypto\KeyGenerationParameters.cs" />
     <Compile Include="src\crypto\MaxBytesExceededException.cs" />
     <Compile Include="src\crypto\OutputLengthException.cs" />
-    <Compile Include="src\crypto\parameters\HKDFParameters.cs" />
+    <Compile Include="src\crypto\parameters\HKdfParameters.cs" />
     <Compile Include="src\crypto\PbeParametersGenerator.cs" />
     <Compile Include="src\crypto\Security.cs" />
     <Compile Include="src\crypto\SimpleBlockResult.cs" />
@@ -889,7 +889,7 @@
     <Compile Include="src\crypto\generators\ElGamalParametersGenerator.cs" />
     <Compile Include="src\crypto\generators\GOST3410KeyPairGenerator.cs" />
     <Compile Include="src\crypto\generators\GOST3410ParametersGenerator.cs" />
-    <Compile Include="src\crypto\generators\HKDFBytesGenerator.cs" />
+    <Compile Include="src\crypto\generators\HKdfBytesGenerator.cs" />
     <Compile Include="src\crypto\generators\Kdf1BytesGenerator.cs" />
     <Compile Include="src\crypto\generators\Kdf2BytesGenerator.cs" />
     <Compile Include="src\crypto\generators\KDFCounterBytesGenerator.cs" />

--- a/crypto/BouncyCastle.iOS.csproj
+++ b/crypto/BouncyCastle.iOS.csproj
@@ -732,7 +732,7 @@
     <Compile Include="src\crypto\KeyGenerationParameters.cs" />
     <Compile Include="src\crypto\MaxBytesExceededException.cs" />
     <Compile Include="src\crypto\OutputLengthException.cs" />
-    <Compile Include="src\crypto\parameters\HKDFParameters.cs" />
+    <Compile Include="src\crypto\parameters\HKdfParameters.cs" />
     <Compile Include="src\crypto\PbeParametersGenerator.cs" />
     <Compile Include="src\crypto\Security.cs" />
     <Compile Include="src\crypto\SimpleBlockResult.cs" />
@@ -884,7 +884,7 @@
     <Compile Include="src\crypto\generators\ElGamalParametersGenerator.cs" />
     <Compile Include="src\crypto\generators\GOST3410KeyPairGenerator.cs" />
     <Compile Include="src\crypto\generators\GOST3410ParametersGenerator.cs" />
-    <Compile Include="src\crypto\generators\HKDFBytesGenerator.cs" />
+    <Compile Include="src\crypto\generators\HKdfBytesGenerator.cs" />
     <Compile Include="src\crypto\generators\Kdf1BytesGenerator.cs" />
     <Compile Include="src\crypto\generators\Kdf2BytesGenerator.cs" />
     <Compile Include="src\crypto\generators\KDFCounterBytesGenerator.cs" />

--- a/crypto/crypto.csproj
+++ b/crypto/crypto.csproj
@@ -4299,7 +4299,7 @@
                     BuildAction = "Compile"
                 />
                 <File
-                    RelPath = "src\crypto\generators\HKDFBytesGenerator.cs"
+                    RelPath = "src\crypto\generators\HKdfBytesGenerator.cs"
                     SubType = "Code"
                     BuildAction = "Compile"
                 />
@@ -4934,7 +4934,7 @@
                     BuildAction = "Compile"
                 />
                 <File
-                    RelPath = "src\crypto\parameters\HKDFParameters.cs"
+                    RelPath = "src\crypto\parameters\HKdfParameters.cs"
                     SubType = "Code"
                     BuildAction = "Compile"
                 />


### PR DESCRIPTION
Commit 196bbb0190164b985580d8c4465f6f10f2306bca changed the casing of two file names but did not update the .cspoj file which breaks building on case-senstiive file systems.