### PR TITLE
Optimize constructors for Time

### DIFF
--- a/crypto/src/asn1/cms/Time.cs
+++ b/crypto/src/asn1/cms/Time.cs
@@ -36,17 +36,15 @@ namespace Org.BouncyCastle.Asn1.Cms
         public Time(
             DateTime date)
         {
-            string d = date.ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) + "Z";
+            DateTime d = date.ToUniversalTime();
 
-			int year = int.Parse(d.Substring(0, 4));
-
-			if (year < 1950 || year > 2049)
+			if (d.Year < 1950 || d.Year > 2049)
             {
                 time = new DerGeneralizedTime(d);
             }
             else
             {
-                time = new DerUtcTime(d.Substring(2));
+                time = new DerUtcTime(d);
             }
         }
 

--- a/crypto/src/asn1/x509/Time.cs
+++ b/crypto/src/asn1/x509/Time.cs
@@ -35,17 +35,15 @@ namespace Org.BouncyCastle.Asn1.X509
          */
         public Time(DateTime date)
         {
-            string d = date.ToUniversalTime().ToString("yyyyMMddHHmmss", CultureInfo.InvariantCulture) + "Z";
+            DateTime d = date.ToUniversalTime();
 
-            int year = int.Parse(d.Substring(0, 4));
-
-            if (year < 1950 || year > 2049)
+            if (d.Year < 1950 || d.Year > 2049)
             {
                 time = new DerGeneralizedTime(d);
             }
             else
             {
-                time = new DerUtcTime(d.Substring(2));
+                time = new DerUtcTime(d);
             }
         }
 


### PR DESCRIPTION
Optimize constructors for `Org.BouncyCastle.Asn1.X509.Time` and `Org.BouncyCastle.Asn1.Cms.Time`.

In the original code, `DateTime` was format to string, from string was parsed year and ASN1 time structure.
I removed unnecessary steps from this code, and instead of parsing strings, `DateTime` is used directly.