### PR TITLE
Add NuGet links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # The Bouncy Castle Cryptography Library For .NET
+[![NuGet](https://img.shields.io/nuget/dt/BouncyCastle.Cryptography.svg)](https://www.nuget.org/packages/BouncyCastle.Cryptography) [![NuGet](https://img.shields.io/nuget/vpre/BouncyCastle.Cryptography.svg)](https://www.nuget.org/packages/BouncyCastle.Cryptography)
 
 The Bouncy Castle Cryptography library is a .NET implementation of cryptographic algorithms and protocols. It was developed by the Legion of the Bouncy Castle, a registered Australian Charity, with a little help! The Legion, and the latest goings on with this package, can be found at [https://www.bouncycastle.org](https://www.bouncycastle.org).
 
@@ -9,6 +10,18 @@ The Legion also gratefully acknowledges the contributions made to this package b
 Except where otherwise stated, this software is distributed under a license based on the MIT X Consortium license. To view the license, [see here](https://www.bouncycastle.org/licence.html). This software includes a modified Bzip2 library, which is licensed under the [Apache Software License, Version 2.0](http://www.apache.org/licenses/). 
 
 **Note**: This source tree is not the FIPS version of the APIs - if you are interested in our FIPS version please visit us [here](https://www.bouncycastle.org/fips-csharp) or contact us directly at [office@bouncycastle.org](mailto:office@bouncycastle.org).
+
+## Installing BouncyCastle
+You should install [BouncyCastle with NuGet:](https://www.nuget.org/packages/BouncyCastle.Cryptography)
+
+    Install-Package BouncyCastle.Cryptography
+
+Or via the .NET Core command line interface:
+
+    dotnet add package BouncyCastle.Cryptography
+
+Either commands, from Package Manager Console or .NET Core CLI, will download and install BouncyCastle.Cryptography.
+
 
 ## Mailing Lists
 


### PR DESCRIPTION
Nuget lists several packages when searching `BouncyCastle` each with different versions and compatibilities, it is not clear which is the official or current version. The README currently does not link to NuGet, instead the user has to go to your website, scroll down and find the official version in the releases section.

This PR adds widgets linking to the NuGet package and a section demonstrating installing this package from NuGet. Hopefully it will help people migrate and boost the pacakges visibility.
