### PR TITLE
Fix for Issue #354. "Error getting Content from CmsEnvelopedData with AES128-GCM"

### DIFF
--- a/crypto/src/security/ParameterUtilities.cs
+++ b/crypto/src/security/ParameterUtilities.cs
@@ -18,6 +18,8 @@ namespace Org.BouncyCastle.Security
 {
     public static class ParameterUtilities
     {
+        private static readonly IList<string> IvUnsupportedAlgorithms = 
+            new List<string> {"RIJNDAEL", "SKIPJACK", "TWOFISH"};
         private static readonly IDictionary<string, string> Algorithms =
             new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
         private static readonly IDictionary<string, int> BasicIVSizes =
@@ -260,10 +262,12 @@ namespace Org.BouncyCastle.Security
                 // "RIJNDAEL", "SKIPJACK", "TWOFISH"
 
                 int basicIVKeySize = FindBasicIVSize(canonical);
-                if (basicIVKeySize != -1
-                    || canonical == "RIJNDAEL" || canonical == "SKIPJACK" || canonical == "TWOFISH")
+                if (basicIVKeySize != -1 || IvUnsupportedAlgorithms.Contains(canonical))
                 {
-                    iv = ((Asn1OctetString) asn1Params).GetOctets();
+                    var sequence = asn1Params as DerSequence;
+                    iv = sequence != null 
+                            ? (sequence[0] as DerOctetString).GetOctets() 
+                            : (asn1Params as Asn1OctetString).GetOctets();
                 }
                 else if (canonical == "CAST5")
                 {

--- a/crypto/test/src/security/test/TestParameterUtil.cs
+++ b/crypto/test/src/security/test/TestParameterUtil.cs
@@ -29,15 +29,16 @@ namespace Org.BouncyCastle.Security.Tests
 				128, typeof(RC2Parameters), random);
 		}
 
-        [Test]
-        public void TestGetCypherParameters_Aes256GcmAsn1ParamsIsDerSequence_ReturnsParameters()
-        {
-            var parameters = ParameterUtilities.GetCipherParameters(
-                NistObjectIdentifiers.IdAes256Gcm.Id, new KeyParameter(new byte[] {0x0}),
-                new DerSequence(new DerOctetString(new byte[] {0x0})));
-            
+		[Test]
+		public void TestGetCypherParameters_Aes256GcmAsn1ParamsIsDerSequence_ReturnsParameters()
+		{
+			var parameters = ParameterUtilities.GetCipherParameters(
+				NistObjectIdentifiers.IdAes256Gcm.Id, 
+				new KeyParameter(new byte[] {0x0}), 
+				new DerSequence(new DerOctetString(new byte[] {0x0})));
+
 			Assert.IsInstanceOf(typeof(ParametersWithIV), parameters);
-        }
+		}
 		
 		private void doTestCreateKeyParameter(
 			string				algorithm,

--- a/crypto/test/src/security/test/TestParameterUtil.cs
+++ b/crypto/test/src/security/test/TestParameterUtil.cs
@@ -29,6 +29,16 @@ namespace Org.BouncyCastle.Security.Tests
 				128, typeof(RC2Parameters), random);
 		}
 
+        [Test]
+        public void TestGetCypherParameters_Aes256GcmAsn1ParamsIsDerSequence_ReturnsParameters()
+        {
+            var parameters = ParameterUtilities.GetCipherParameters(
+                NistObjectIdentifiers.IdAes256Gcm.Id, new KeyParameter(new byte[] {0x0}),
+                new DerSequence(new DerOctetString(new byte[] {0x0})));
+            
+			Assert.IsInstanceOf(typeof(ParametersWithIV), parameters);
+        }
+		
 		private void doTestCreateKeyParameter(
 			string				algorithm,
 			DerObjectIdentifier	oid,


### PR DESCRIPTION
This is a fix for issue #354 . As I commented on the issue, I have limited knowledge about this so it would be nice if you can review this PR and ensure that this fix doesn't cause any incompatibility with other parts of the library.