### PR TITLE
Fixed cache in DerObjectIdentifier

### DIFF
--- a/crypto/src/asn1/DerObjectIdentifier.cs
+++ b/crypto/src/asn1/DerObjectIdentifier.cs
@@ -208,7 +208,7 @@ namespace Org.BouncyCastle.Asn1
         {
             int hashCode = Arrays.GetHashCode(contents);
 
-            DerObjectIdentifier entry = cache.GetOrAdd(hashCode, new DerObjectIdentifier(contents, clone));
+            DerObjectIdentifier entry = cache.GetOrAdd(hashCode, _ => new DerObjectIdentifier(contents, clone));
 
             if (!Arrays.AreEqual(contents, entry.GetContents()))
             {


### PR DESCRIPTION
In the process of profiling an application that performs the improvement of a large number of signatures to the CAdES-XL format in parallel in many threads, I found that this lock is a "bottleneck".
Therefore, I tried to replace the explicit lock with the use of ConcurrentDictionary, which significantly accelerated the process.
It also turned out that applying the 1023 bit mask to HashCode leads to a large number of cache misses both in the tests of this project and on my real data, so it was removed, without it cache misses are no longer observed, but I did not delete the code handling this situation.