### PR TITLE
Removing unnecessary locks in X509Certificate and X509Crl

### DIFF
--- a/crypto/src/x509/X509Certificate.cs
+++ b/crypto/src/x509/X509Certificate.cs
@@ -477,8 +477,7 @@ namespace Org.BouncyCastle.X509
 
             AsymmetricKeyParameter temp = PublicKeyFactory.CreateKey(c.SubjectPublicKeyInfo);
 
-            Interlocked.CompareExchange(ref publicKeyValue, temp, null);
-            return publicKeyValue;
+            return Interlocked.CompareExchange(ref publicKeyValue, temp, null) ?? temp;
         }
 
         /// <summary>
@@ -699,8 +698,7 @@ namespace Org.BouncyCastle.X509
 
             CachedEncoding temp = new CachedEncoding(encoding, exception);
 
-            Interlocked.CompareExchange(ref cachedEncoding, temp, null);
-            return cachedEncoding;
+           return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
         }
 
         private static bool IsAlgIDEqual(AlgorithmIdentifier id1, AlgorithmIdentifier id2)

--- a/crypto/src/x509/X509Certificate.cs
+++ b/crypto/src/x509/X509Certificate.cs
@@ -698,7 +698,7 @@ namespace Org.BouncyCastle.X509
 
             CachedEncoding temp = new CachedEncoding(encoding, exception);
 
-           return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
+            return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
         }
 
         private static bool IsAlgIDEqual(AlgorithmIdentifier id1, AlgorithmIdentifier id2)

--- a/crypto/src/x509/X509Crl.cs
+++ b/crypto/src/x509/X509Crl.cs
@@ -466,8 +466,7 @@ namespace Org.BouncyCastle.X509
 
             CachedEncoding temp = new CachedEncoding(encoding, exception);
 
-			Interlocked.CompareExchange(ref cachedEncoding, temp, null);
-            return cachedEncoding;
+			return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
         }
     }
 }

--- a/crypto/src/x509/X509Crl.cs
+++ b/crypto/src/x509/X509Crl.cs
@@ -449,7 +449,7 @@ namespace Org.BouncyCastle.X509
 
         private CachedEncoding GetCachedEncoding()
         {
-			CachedEncoding localCacheEncoding = cachedEncoding;
+            CachedEncoding localCacheEncoding = cachedEncoding;
             if (null != localCacheEncoding)
                 return localCacheEncoding;
 
@@ -466,7 +466,7 @@ namespace Org.BouncyCastle.X509
 
             CachedEncoding temp = new CachedEncoding(encoding, exception);
 
-			return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
+            return Interlocked.CompareExchange(ref cachedEncoding, temp, null) ?? temp;
         }
     }
 }


### PR DESCRIPTION
Lock with null check is replaced to assign to local variable (is atomic) and null check.

Lock with condition assign is replaced to `Interlocked.CompareExchange`.