### PR TITLE
make initial DTLS handshake resend time configurable

### DIFF
--- a/crypto/src/tls/AbstractTlsPeer.cs
+++ b/crypto/src/tls/AbstractTlsPeer.cs
@@ -65,6 +65,11 @@ namespace Org.BouncyCastle.Tls
             return 0;
         }
 
+        public virtual int GetHandshakeResendTimeMillis()
+        {
+            return 1000;
+        }
+
         public virtual bool AllowLegacyResumption()
         {
             return false;

--- a/crypto/src/tls/DtlsClientProtocol.cs
+++ b/crypto/src/tls/DtlsClientProtocol.cs
@@ -100,7 +100,7 @@ namespace Org.BouncyCastle.Tls
             SecurityParameters securityParameters = state.clientContext.SecurityParameters;
 
             DtlsReliableHandshake handshake = new DtlsReliableHandshake(state.clientContext, recordLayer,
-                state.client.GetHandshakeTimeoutMillis(), null);
+                state.client.GetHandshakeTimeoutMillis(), state.client.GetHandshakeResendTimeMillis(), null);
 
             byte[] clientHelloBody = GenerateClientHello(state);
 

--- a/crypto/src/tls/DtlsRecordLayer.cs
+++ b/crypto/src/tls/DtlsRecordLayer.cs
@@ -268,7 +268,7 @@ namespace Org.BouncyCastle.Tls
                         HeartbeatMessageType.heartbeat_request, m_heartbeat.GeneratePayload());
                     this.m_heartbeatTimeout = new Timeout(m_heartbeat.TimeoutMillis, currentTimeMillis);
 
-                    this.m_heartbeatResendMillis = DtlsReliableHandshake.INITIAL_RESEND_MILLIS;
+                    this.m_heartbeatResendMillis = m_peer.GetHandshakeResendTimeMillis();
                     this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
 
                     SendHeartbeatMessage(m_heartbeatInFlight);
@@ -338,7 +338,7 @@ namespace Org.BouncyCastle.Tls
                         HeartbeatMessageType.heartbeat_request, m_heartbeat.GeneratePayload());
                     this.m_heartbeatTimeout = new Timeout(m_heartbeat.TimeoutMillis, currentTimeMillis);
 
-                    this.m_heartbeatResendMillis = DtlsReliableHandshake.INITIAL_RESEND_MILLIS;
+                    this.m_heartbeatResendMillis = m_peer.GetHandshakeResendTimeMillis();
                     this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
 
                     SendHeartbeatMessage(m_heartbeatInFlight);

--- a/crypto/src/tls/DtlsReliableHandshake.cs
+++ b/crypto/src/tls/DtlsReliableHandshake.cs
@@ -11,7 +11,6 @@ namespace Org.BouncyCastle.Tls
         private const int MAX_RECEIVE_AHEAD = 16;
         private const int MESSAGE_HEADER_LENGTH = 12;
 
-        internal const int INITIAL_RESEND_MILLIS = 1000;
         private const int MAX_RESEND_MILLIS = 60000;
 
         /// <exception cref="IOException"/>
@@ -85,21 +84,23 @@ namespace Org.BouncyCastle.Tls
         private IDictionary<int, DtlsReassembler> m_previousInboundFlight = null;
         private IList<Message> m_outboundFlight = new List<Message>();
 
+        private readonly int m_initialResendMillis;
         private int m_resendMillis = -1;
         private Timeout m_resendTimeout = null;
 
         private int m_next_send_seq = 0, m_next_receive_seq = 0;
 
-        internal DtlsReliableHandshake(TlsContext context, DtlsRecordLayer transport, int timeoutMillis,
+        internal DtlsReliableHandshake(TlsContext context, DtlsRecordLayer transport, int timeoutMillis, int initialResendMillis,
             DtlsRequest request)
         {
             this.m_recordLayer = transport;
             this.m_handshakeHash = new DeferredHash(context);
             this.m_handshakeTimeout = Timeout.ForWaitMillis(timeoutMillis);
+            m_initialResendMillis = initialResendMillis;
 
             if (null != request)
             {
-                this.m_resendMillis = INITIAL_RESEND_MILLIS;
+                this.m_resendMillis = m_initialResendMillis;
                 this.m_resendTimeout = new Timeout(m_resendMillis);
 
                 long recordSeq = request.RecordSeq;
@@ -298,7 +299,7 @@ namespace Org.BouncyCastle.Tls
 
             if (null == m_resendTimeout)
             {
-                m_resendMillis = INITIAL_RESEND_MILLIS;
+                m_resendMillis = m_initialResendMillis;
                 m_resendTimeout = new Timeout(m_resendMillis, currentTimeMillis);
 
                 PrepareInboundFlight(new Dictionary<int, DtlsReassembler>());

--- a/crypto/src/tls/DtlsServerProtocol.cs
+++ b/crypto/src/tls/DtlsServerProtocol.cs
@@ -89,7 +89,7 @@ namespace Org.BouncyCastle.Tls
             SecurityParameters securityParameters = state.serverContext.SecurityParameters;
 
             DtlsReliableHandshake handshake = new DtlsReliableHandshake(state.serverContext, recordLayer,
-                state.server.GetHandshakeTimeoutMillis(), request);
+                state.server.GetHandshakeTimeoutMillis(), state.server.GetHandshakeResendTimeMillis(), request);
 
             DtlsReliableHandshake.Message clientMessage = null;
 

--- a/crypto/src/tls/TlsPeer.cs
+++ b/crypto/src/tls/TlsPeer.cs
@@ -31,6 +31,13 @@ namespace Org.BouncyCastle.Tls
         /// <returns>the handshake timeout, in milliseconds.</returns>
         int GetHandshakeTimeoutMillis();
 
+        /// <summary>Specify the time, in milliseconds, after which a handshake packet is resent.</summary>
+        /// <remarks>
+        /// NOTE: Currently only respected by DTLS protocols.
+        /// </remarks>
+        /// <returns>the handshake resend time, in milliseconds.</returns>
+        int GetHandshakeResendTimeMillis();
+
         bool AllowLegacyResumption();
 
         int GetMaxCertificateChainLength();


### PR DESCRIPTION
This PR makes the initial time after which a DTLS handshake packet is resent (after getting no response) configurable.
This can be useful to reduce unneccessary retransmissions in networks that are usually reliable, but have a high latency (some mobile networks do) and/or when working with low-power embedded devices that might take a few seconds to run the key exchange algorithms.