### PR TITLE
Update SPHINCSPlusParameters.cs

### DIFF
--- a/crypto/src/pqc/crypto/sphincsplus/SPHINCSPlusParameters.cs
+++ b/crypto/src/pqc/crypto/sphincsplus/SPHINCSPlusParameters.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 
 using Org.BouncyCastle.Crypto.Utilities;
+using Org.BouncyCastle.Crypto;
 
 namespace Org.BouncyCastle.Pqc.Crypto.SphincsPlus
 {
@@ -12,7 +13,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.SphincsPlus
         SphincsPlusEngine Get();
     }
 
-    public sealed class SphincsPlusParameters
+    public sealed class SphincsPlusParameters : ICipherParameters
     {
         public static SphincsPlusParameters sha2_128f = new SphincsPlusParameters("sha2-128f-robust",
             new Sha2EngineProvider(true, 16, 16, 22, 6, 33, 66));


### PR DESCRIPTION
FYI: The `SphincsPlusParameters` doesn't implement the `ICipherParameters`, which breaks the API standard that is implemented by most (or all) of the other algorithms.