### PR TITLE
Update SignerId.cs

### DIFF
--- a/crypto/src/cms/SignerId.cs
+++ b/crypto/src/cms/SignerId.cs
@@ -36,7 +36,7 @@ namespace Org.BouncyCastle.Cms
             object obj)
         {
 			if (obj == this)
-				return false;
+				return true;
 
 			SignerID id = obj as SignerID;
 


### PR DESCRIPTION
When there is reference equality, Equals() should return true. I encounter this issue when calling SignerInformationStore.GetFirstSigner().