### PR TITLE
Adding PBEWITHSHA1ANDDESEDE Algorithm to PbeUtilities.cs

### DIFF
--- a/crypto/src/security/PbeUtilities.cs
+++ b/crypto/src/security/PbeUtilities.cs
@@ -86,6 +86,7 @@ namespace Org.BouncyCastle.Security
             Algorithms["PBEWITHSHA1AND3-KEYDESEDE-CBC"] = "PBEwithSHA-1and3-keyDESEDE-CBC";
             Algorithms["PBEWITHSHA1AND3-KEYTRIPLEDES-CBC"] = "PBEwithSHA-1and3-keyDESEDE-CBC";
             Algorithms["PBEWITHSHA-1AND3-KEYDESEDE-CBC"] = "PBEwithSHA-1and3-keyDESEDE-CBC";
+            Algorithms["PBEWITHSHA1ANDDESEDE"] = "PBEwithSHA-1and3-keyDESEDE-CBC";
             Algorithms["PBEWITHSHA-1AND3-KEYTRIPLEDES-CBC"] = "PBEwithSHA-1and3-keyDESEDE-CBC";
             Algorithms[PkcsObjectIdentifiers.PbeWithShaAnd3KeyTripleDesCbc.Id] = "PBEwithSHA-1and3-keyDESEDE-CBC";
             Algorithms["PBEWITHSHAAND2-KEYDESEDE-CBC"] = "PBEwithSHA-1and2-keyDESEDE-CBC";


### PR DESCRIPTION
The 'PBEWITHSHA1ANDDESEDE' Algorithm exists in the CipherUtilities.cs, but seems to be missing here, which causes a NullReference exception.