### PR TITLE
Added SRP message verification using RFC2945

### DIFF
--- a/crypto/src/crypto/agreement/srp/SRP6Client.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6Client.cs
@@ -16,7 +16,7 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
         private bool isRFC2945 = false;
 
         protected BigInteger N;
-	    protected BigInteger g;
+        protected BigInteger g;
 
 	    protected BigInteger privA;
 	    protected BigInteger pubA;
@@ -118,7 +118,7 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 		    }
 		    // compute the client evidence message 'M1'
 		    this.M1 = Srp6Utilities.CalculateM1(digest, N, pubA, B, S);
-			this.isRFC2945 = false;
+		    this.isRFC2945 = false;
 
             return M1;
 	    }
@@ -167,19 +167,19 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 			// Compute the own server evidence message 'M2'
 			BigInteger computedM2;
 						
-			if(isRFC2945)
-			{
-				computedM2 = Srp6Utilities.CalculateM2(digest, N, pubA, M1, Key);
-			}
-			else
-			{
-                computedM2 = Srp6Utilities.CalculateM2(digest, N, pubA, M1, S);
-            }
-		    
-			if (computedM2.Equals(serverM2))
+		    if(isRFC2945)
 		    {
-			    this.M2 = serverM2;
-			    return true;
+			    computedM2 = Srp6Utilities.CalculateM2(digest, N, pubA, M1, Key);
+		    }
+		    else
+		    {
+		        computedM2 = Srp6Utilities.CalculateM2(digest, N, pubA, M1, S);
+		    }
+		    
+		    if (computedM2.Equals(serverM2))
+		    {
+		        this.M2 = serverM2;
+		        return true;
 		    }
 		    return false;
 	    }

--- a/crypto/src/crypto/agreement/srp/SRP6Server.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6Server.cs
@@ -31,6 +31,8 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
         protected BigInteger M2;
         protected BigInteger Key;
 
+		private bool isRFC2945 = false;
+
 	    public Srp6Server()
 	    {
 	    }
@@ -117,10 +119,44 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 		    if (computedM1.Equals(clientM1))
 		    {
 			    this.M1 = clientM1;
+                this.isRFC2945 = false;
 			    return true;
 		    }
 		    return false;
 	    }
+
+        /** 
+	     * Authenticates the received client evidence message M1 using RFC2945 and saves it only if correct.
+	     * To be called after calculating the secret S.
+	     * @param M1: the client side generated evidence message
+	     * @param messageVerifier: message verifier pre-generated from identity and salt
+	     * @return A boolean indicating if the client message M1 was the expected one.
+	     * @throws CryptoException 
+	     */
+        public virtual bool VerifyClientEvidenceMessageRFC2945(BigInteger clientM1, byte[] messageVerifier)
+        {
+            // Verify pre-requirements
+            if (this.A == null || this.pubB == null || this.S == null || messageVerifier == null)
+            {
+                throw new CryptoException("Impossible to compute and verify M1: " +
+                        "some data are missing from the previous operations (A,B,S,messageVerifier)");
+            }
+
+            if (this.Key == null)
+            {
+                this.Key = Srp6Utilities.CalculateKey(digest, N, S);
+            }
+
+            // Compute the own client evidence message 'M1'
+            BigInteger computedM1 = Srp6Utilities.CalculateM1(digest, N, g, A, pubB, Key, messageVerifier);
+            if (computedM1.Equals(clientM1))
+            {
+                this.M1 = clientM1;
+                this.isRFC2945 = true;
+                return true;
+            }
+            return false;
+        }
 
         /**
 	     * Computes the server evidence message M2 using the previously verified values.
@@ -137,8 +173,15 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 					    "some data are missing from the previous operations (A,M1,S)");
 		    }
 
-            // Compute the server evidence message 'M2'
-		    this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, S);  
+			// Compute the server evidence message 'M2'
+			if (isRFC2945)
+			{
+                this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, Key);
+            }
+			else
+			{
+				this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, S);
+			}
 		    return M2;
 	    }
 

--- a/crypto/src/crypto/agreement/srp/SRP6Server.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6Server.cs
@@ -116,14 +116,14 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 
 		    // Compute the own client evidence message 'M1'
 		    BigInteger computedM1 = Srp6Utilities.CalculateM1(digest, N, A, pubB, S);
-		    if (computedM1.Equals(clientM1))
-		    {
-			    this.M1 = clientM1;
+            if (computedM1.Equals(clientM1))
+            {
+                this.M1 = clientM1;
                 this.isRFC2945 = false;
-			    return true;
-		    }
-		    return false;
-	    }
+                return true;
+            }
+            return false;
+        }
 
         /** 
 	     * Authenticates the received client evidence message M1 using RFC2945 and saves it only if correct.
@@ -164,26 +164,26 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 	     * @return M2: the server side generated evidence message
 	     * @throws CryptoException
 	     */
-	    public virtual BigInteger CalculateServerEvidenceMessage()
-	    {
-		    // Verify pre-requirements
-		    if (this.A == null || this.M1 == null || this.S == null)
-		    {
-			    throw new CryptoException("Impossible to compute M2: " +
-					    "some data are missing from the previous operations (A,M1,S)");
-		    }
+        public virtual BigInteger CalculateServerEvidenceMessage()
+        {
+            // Verify pre-requirements
+            if (this.A == null || this.M1 == null || this.S == null)
+            {
+                throw new CryptoException("Impossible to compute M2: " +
+                   "some data are missing from the previous operations (A,M1,S)");
+            }
 
-			// Compute the server evidence message 'M2'
-			if (isRFC2945)
-			{
+            // Compute the server evidence message 'M2'
+            if (isRFC2945)
+            {
                 this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, Key);
             }
-			else
-			{
-				this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, S);
-			}
-		    return M2;
-	    }
+            else
+            {
+                this.M2 = Srp6Utilities.CalculateM2(digest, N, A, M1, S);
+            }
+            return M2;
+        }
 
         /**
 	     * Computes the final session key as a result of the SRP successful mutual authentication

--- a/crypto/src/crypto/agreement/srp/SRP6Utilities.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6Utilities.cs
@@ -122,12 +122,7 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
             byte[] bA = VALUEOF(A);
             byte[] bB = VALUEOF(B);
             byte[] bK = VALUEOF(K, digest.GetDigestSize());
-
-            System.Diagnostics.Debug.WriteLine($"---K: {Convert.ToBase64String(bK)}");
-
             byte[] bM1 = SHA(digest, CONCAT(XOR(SHA(digest, N), SHA(digest, g)), CONCAT(messageVerifier, CONCAT(bA, CONCAT(bB, bK)))));
-            System.Diagnostics.Debug.WriteLine($"---M1: {Convert.ToBase64String(bM1)}");
-
             BigInteger M1 = new BigInteger(1, bM1);
             return M1;
         }

--- a/crypto/src/crypto/agreement/srp/SRP6Utilities.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6Utilities.cs
@@ -64,10 +64,10 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
         public static byte[] CalculateY(IDigest digest, byte[] salt, byte[] identity)
         {
             byte[] output = new byte[digest.GetDigestSize()];
-	        digest.BlockUpdate(identity, 0, identity.Length);
-	        digest.DoFinal(output, 0);
-	        output = output.Concat(salt).ToArray();
-	        return output;
+            digest.BlockUpdate(identity, 0, identity.Length);
+            digest.DoFinal(output, 0);
+            output = output.Concat(salt).ToArray();
+            return output;
         }
 
         public static BigInteger GeneratePrivateValue(IDigest digest, BigInteger N, BigInteger g, SecureRandom random)

--- a/crypto/src/crypto/agreement/srp/SRP6VerifierGenerator.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6VerifierGenerator.cs
@@ -50,6 +50,18 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 
 	        return g.ModPow(x, N);
 	    }
-	}
+
+        /**
+	     * Creates a new SRP verifier for M1
+	     * @param salt The salt to use, generally should be large and random
+	     * @param identity The user's identifying information (eg. username)
+	     * @return A new verifier for use in future SRP authentication
+	     */
+        public virtual byte[] GenerateMessageVerifierRFC2945(byte[] salt, byte[] identity)
+        {
+            byte[] mv = Srp6Utilities.CalculateY(digest, salt, identity);
+            return mv;
+        }
+    }
 }
 

--- a/crypto/src/crypto/agreement/srp/SRP6VerifierGenerator.cs
+++ b/crypto/src/crypto/agreement/srp/SRP6VerifierGenerator.cs
@@ -51,12 +51,12 @@ namespace Org.BouncyCastle.Crypto.Agreement.Srp
 	        return g.ModPow(x, N);
 	    }
 
-        /**
-	     * Creates a new SRP verifier for M1
-	     * @param salt The salt to use, generally should be large and random
-	     * @param identity The user's identifying information (eg. username)
-	     * @return A new verifier for use in future SRP authentication
-	     */
+       /**
+        * Creates a new SRP verifier for M1
+        * @param salt The salt to use, generally should be large and random
+        * @param identity The user's identifying information (eg. username)
+        * @return A new verifier for use in future SRP authentication
+        */
         public virtual byte[] GenerateMessageVerifierRFC2945(byte[] salt, byte[] identity)
         {
             byte[] mv = Srp6Utilities.CalculateY(digest, salt, identity);

--- a/crypto/test/src/crypto/test/SRP6Test.cs
+++ b/crypto/test/src/crypto/test/SRP6Test.cs
@@ -32,20 +32,20 @@ namespace Org.BouncyCastle.Crypto.Tests
 
 	    public override void PerformTest()
 	    {
-	    	rfc5054AppendixBTestVectors();
-			rfc2945MessageVerify();
+            rfc5054AppendixBTestVectors();
+            rfc2945MessageVerify();
 
             testMutualVerification(Srp6StandardGroups.rfc5054_1024);
             testClientCatchesBadB(Srp6StandardGroups.rfc5054_1024);
             testServerCatchesBadA(Srp6StandardGroups.rfc5054_1024);
 
-			testWithRandomParams(256);
-			testWithRandomParams(384);
-			testWithRandomParams(512);
-	    }
+            testWithRandomParams(256);
+            testWithRandomParams(384);
+            testWithRandomParams(512);
+        }
 
         private void rfc2945MessageVerify()
-		{
+        {
             BigInteger N = Srp6StandardGroups.rfc5054_1024.N;
             BigInteger g = Srp6StandardGroups.rfc5054_1024.G;
 
@@ -54,7 +54,7 @@ namespace Org.BouncyCastle.Crypto.Tests
             byte[] s = new byte[16];
             random.NextBytes(s);
 
-			var group = new Srp6GroupParameters(N, g);
+            var group = new Srp6GroupParameters(N, g);
 
             Srp6VerifierGenerator gen = new Srp6VerifierGenerator();
             gen.Init(group, new Sha256Digest());
@@ -71,7 +71,7 @@ namespace Org.BouncyCastle.Crypto.Tests
             BigInteger B = server.GenerateServerCredentials();
 
             BigInteger clientS = client.CalculateSecret(B);
-			BigInteger clientM1 = client.CalculateClientEvidenceMessageRFC2945(messageVerifier);
+            BigInteger clientM1 = client.CalculateClientEvidenceMessageRFC2945(messageVerifier);
 
             BigInteger serverS = server.CalculateSecret(A);
 
@@ -82,13 +82,13 @@ namespace Org.BouncyCastle.Crypto.Tests
 
             bool isClientM1Valid =  server.VerifyClientEvidenceMessageRFC2945(clientM1, messageVerifier);
             if(!isClientM1Valid)
-			{
+            {
                 Fail("SRP server was not able to verify M1 from the client");
             }
 
-			BigInteger serverM2 = server.CalculateServerEvidenceMessage();
-			bool isServerM2Valid = client.VerifyServerEvidenceMessage(serverM2);
-			if(!isServerM2Valid)
+            BigInteger serverM2 = server.CalculateServerEvidenceMessage();
+            bool isServerM2Valid = client.VerifyServerEvidenceMessage(serverM2);
+            if (!isServerM2Valid)
             {
                 Fail("SRP client was not able to verify M2 from the server");
             }


### PR DESCRIPTION
Added methods for calculating M1 using the formula described in RFC 2945. I tried to avoid any breaking changes, which is why the PR just adds new methods while keeping the original implementation unchanged.