### PR TITLE
Get rid of a large number of allocations

### DIFF
--- a/crypto/src/BouncyCastle.Crypto.csproj
+++ b/crypto/src/BouncyCastle.Crypto.csproj
@@ -2,9 +2,11 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;netstandard2.0;net461</TargetFrameworks>
+    <LangVersion>12</LangVersion>
     <RootNamespace>Org.BouncyCastle</RootNamespace>
     <AssemblyOriginatorKeyFile>..\..\BouncyCastle.NET.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<NoWarn>1591</NoWarn>
 
     <AssemblyName>BouncyCastle.Cryptography</AssemblyName>

--- a/crypto/src/BouncyCastle.Crypto.csproj
+++ b/crypto/src/BouncyCastle.Crypto.csproj
@@ -6,7 +6,6 @@
     <RootNamespace>Org.BouncyCastle</RootNamespace>
     <AssemblyOriginatorKeyFile>..\..\BouncyCastle.NET.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>
-    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
 	<NoWarn>1591</NoWarn>
 
     <AssemblyName>BouncyCastle.Cryptography</AssemblyName>

--- a/crypto/src/crypto/engines/AesEngine_X86.cs
+++ b/crypto/src/crypto/engines/AesEngine_X86.cs
@@ -13,7 +13,7 @@ namespace Org.BouncyCastle.Crypto.Engines
     using Aes = System.Runtime.Intrinsics.X86.Aes;
     using Sse2 = System.Runtime.Intrinsics.X86.Sse2;
 
-    public unsafe struct AesEngine_X86
+    public struct AesEngine_X86
         : IBlockCipher
     {
         public static bool IsSupported => Org.BouncyCastle.Runtime.Intrinsics.X86.Aes.IsEnabled;
@@ -49,7 +49,7 @@ namespace Org.BouncyCastle.Crypto.Engines
                 length = 13;
                 K = K[..length];
 
-                    var s1 = Load128(key[..16]);
+                var s1 = Load128(key[..16]);
                 var s2 = Load64(key[16..24]).ToVector128();
                 K[0] = s1;
 

--- a/crypto/src/crypto/engines/AesEngine_X86.cs
+++ b/crypto/src/crypto/engines/AesEngine_X86.cs
@@ -13,22 +13,21 @@ namespace Org.BouncyCastle.Crypto.Engines
     using Aes = System.Runtime.Intrinsics.X86.Aes;
     using Sse2 = System.Runtime.Intrinsics.X86.Sse2;
 
-    public struct AesEngine_X86
+    public unsafe struct AesEngine_X86
         : IBlockCipher
     {
         public static bool IsSupported => Org.BouncyCastle.Runtime.Intrinsics.X86.Aes.IsEnabled;
 
-        private static Vector128<byte>[] CreateRoundKeys(ReadOnlySpan<byte> key, bool forEncryption)
+        private static void CreateRoundKeys(ReadOnlySpan<byte> key, bool forEncryption, Span<Vector128<byte>> K, out int length)
         {
-            Vector128<byte>[] K;
-
             switch (key.Length)
             {
             case 16:
             {
                 ReadOnlySpan<byte> rcon = stackalloc byte[]{ 0x01, 0x02, 0x04, 0x08, 0x10, 0x20, 0x40, 0x80, 0x1b, 0x36 };
 
-                K = new Vector128<byte>[11];
+                length = 11;
+                K = K[..length];
 
                 var s = Load128(key[..16]);
                 K[0] = s;
@@ -47,9 +46,10 @@ namespace Org.BouncyCastle.Crypto.Engines
             }
             case 24:
             {
-                K = new Vector128<byte>[13];
+                length = 13;
+                K = K[..length];
 
-                var s1 = Load128(key[..16]);
+                    var s1 = Load128(key[..16]);
                 var s2 = Load64(key[16..24]).ToVector128();
                 K[0] = s1;
 
@@ -93,7 +93,8 @@ namespace Org.BouncyCastle.Crypto.Engines
             }
             case 32:
             {
-                K = new Vector128<byte>[15];
+                length = 15;
+                K = K[..length];
 
                 var s1 = Load128(key[..16]);
                 var s2 = Load128(key[16..32]);
@@ -134,15 +135,19 @@ namespace Org.BouncyCastle.Crypto.Engines
                     K[i] = Aes.InverseMixColumns(K[i]);
                 }
 
-                Array.Reverse(K);
+                K.Reverse();
             }
-
-            return K;
         }
 
         private enum Mode { DEC_128, DEC_192, DEC_256, ENC_128, ENC_192, ENC_256, UNINITIALIZED };
 
-        private Vector128<byte>[] m_roundKeys = null;
+        struct Keys
+        {
+            public Vector128<byte> k0, k1, k2, k3, k4, k5, k6, k7, k8, k9, k10, k11, k12, k13, k14;
+        }
+        private Keys keys;
+        private int keysLength = 15;
+        private Span<Vector128<byte>> m_roundKeys => MemoryMarshal.Cast<Keys, Vector128<byte>>(MemoryMarshal.CreateSpan(ref keys, 1))[..keysLength];
         private Mode m_mode = Mode.UNINITIALIZED;
 
         public AesEngine_X86()
@@ -163,7 +168,9 @@ namespace Org.BouncyCastle.Crypto.Engines
                 throw new ArgumentException("invalid type: " + Platform.GetTypeName(parameters), nameof(parameters));
             }
 
-            m_roundKeys = CreateRoundKeys(keyParameter.Key, forEncryption);
+            keysLength = 15;
+            m_roundKeys.Fill(default);
+            CreateRoundKeys(keyParameter.Key, forEncryption, m_roundKeys, out keysLength);
 
             if (m_roundKeys.Length == 11)
             {
@@ -250,7 +257,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Decrypt128(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Decrypt128(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[10];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -267,7 +274,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Decrypt192(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Decrypt192(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[12];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -286,7 +293,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Decrypt256(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Decrypt256(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[14];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -307,7 +314,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void DecryptFour128(Vector128<byte>[] rk,
+        private static void DecryptFour128(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[10];
@@ -369,7 +376,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void DecryptFour192(Vector128<byte>[] rk,
+        private static void DecryptFour192(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[12];
@@ -441,7 +448,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void DecryptFour256(Vector128<byte>[] rk,
+        private static void DecryptFour256(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[14];
@@ -523,7 +530,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Encrypt128(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Encrypt128(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[10];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -540,7 +547,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Encrypt192(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Encrypt192(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[12];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -559,7 +566,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void Encrypt256(Vector128<byte>[] roundKeys, ref Vector128<byte> state)
+        private static void Encrypt256(ReadOnlySpan<Vector128<byte>> roundKeys, ref Vector128<byte> state)
         {
             var bounds = roundKeys[14];
             var value = Sse2.Xor(state, roundKeys[0]);
@@ -580,7 +587,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void EncryptFour128(Vector128<byte>[] rk,
+        private static void EncryptFour128(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[10];
@@ -642,7 +649,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void EncryptFour192(Vector128<byte>[] rk,
+        private static void EncryptFour192(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[12];
@@ -714,7 +721,7 @@ namespace Org.BouncyCastle.Crypto.Engines
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private static void EncryptFour256(Vector128<byte>[] rk,
+        private static void EncryptFour256(ReadOnlySpan<Vector128<byte>> rk,
             ref Vector128<byte> s1, ref Vector128<byte> s2, ref Vector128<byte> s3, ref Vector128<byte> s4)
         {
             var bounds = rk[14];

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -1043,7 +1043,7 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
-                public void Reset()
+        public void Reset()
         {
             Reset(true);
         }

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -1,5 +1,6 @@
 using System;
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
 using System.Runtime.CompilerServices;
 #endif
 #if NETCOREAPP3_0_OR_GREATER
@@ -988,7 +989,7 @@ namespace Org.BouncyCastle.Crypto.Modes
                 long c = (long)(((totalLength * 8) + 127) >> 7);
 
                 // Calculate the adjustment factor
-                byte[] H_c = new byte[16];
+                Span<byte> H_c = stackalloc byte[16];
                 if (exp == null)
                 {
                     exp = new BasicGcmExponentiator();
@@ -1042,23 +1043,36 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
-        public void Reset()
+                public void Reset()
         {
             Reset(true);
+        }
+
+        static void Reset<T>(ref T[] array, int size)
+        {
+            if (array is null || array.Length != size)
+            {
+                array = new T[size];
+            }
+            else
+            {
+                Arrays.Fill(array, default);
+            }
         }
 
         private void Reset(bool clearMac)
         {
             // note: we do not reset the nonce.
 
-            S = new byte[BlockSize];
-            S_at = new byte[BlockSize];
-            S_atPre = new byte[BlockSize];
-            atBlock = new byte[BlockSize];
+            Reset(ref S, BlockSize);
+            Reset(ref S_at, BlockSize);
+            Reset(ref S_atPre, BlockSize);
+            Reset(ref atBlock, BlockSize);
             atBlockPos = 0;
             atLength = 0;
             atLengthPre = 0;
-            counter = Arrays.Clone(J0);
+            Reset(ref counter, BlockSize);
+            J0.CopyTo(counter, 0);
             counter32 = Pack.BE_To_UInt32(counter, 12);
             blocksRemaining = uint.MaxValue - 1;
             bufOff = 0;

--- a/crypto/src/crypto/modes/gcm/BasicGcmExponentiator.cs
+++ b/crypto/src/crypto/modes/gcm/BasicGcmExponentiator.cs
@@ -12,8 +12,15 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
         {
             GcmUtilities.AsFieldElement(x, out this.x);
         }
-
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         public void ExponentiateX(long pow, byte[] output)
+        {
+            ExponentiateX(pow, output.AsSpan());
+        }
+        public void ExponentiateX(long pow, Span<byte> output)
+#else
+        public void ExponentiateX(long pow, byte[] output)
+#endif
         {
             GcmUtilities.FieldElement y;
             GcmUtilities.One(out y);

--- a/crypto/src/crypto/modes/gcm/GcmUtilities.cs
+++ b/crypto/src/crypto/modes/gcm/GcmUtilities.cs
@@ -39,6 +39,15 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
             Pack.UInt64_To_BE(x1, z, 8);
         }
 
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AsBytes(ulong x0, ulong x1, Span<byte> z)
+        {
+            Pack.UInt64_To_BE(x0, z, 0);
+            Pack.UInt64_To_BE(x1, z, 8);
+        }
+#endif
+
 #if NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
 #endif
@@ -46,6 +55,14 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
         {
             AsBytes(x.n0, x.n1, z);
         }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AsBytes(ref FieldElement x, Span<byte> z)
+        {
+            AsBytes(x.n0, x.n1, z);
+        }
+#endif
 
 #if NETSTANDARD1_0_OR_GREATER || NETCOREAPP1_0_OR_GREATER
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -55,6 +72,15 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
             z.n0 = Pack.BE_To_UInt64(x, 0);
             z.n1 = Pack.BE_To_UInt64(x, 8);
         }
+
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal static void AsFieldElement(ReadOnlySpan<byte> x, out FieldElement z)
+        {
+            z.n0 = Pack.BE_To_UInt64(x, 0);
+            z.n1 = Pack.BE_To_UInt64(x, 8);
+        }
+#endif
 
         internal static void DivideP(ref FieldElement x, out FieldElement z)
         {
@@ -72,6 +98,15 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
             Multiply(ref X, ref Y);
             AsBytes(ref X, x);
         }
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        internal static void Multiply(Span<byte> x, ReadOnlySpan<byte> y)
+        {
+            AsFieldElement(x, out FieldElement X);
+            AsFieldElement(y, out FieldElement Y);
+            Multiply(ref X, ref Y);
+            AsBytes(ref X, x);
+        }
+#endif
 
         internal static void Multiply(ref FieldElement x, ref FieldElement y)
         {

--- a/crypto/src/crypto/modes/gcm/IGcmExponentiator.cs
+++ b/crypto/src/crypto/modes/gcm/IGcmExponentiator.cs
@@ -6,6 +6,9 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
     public interface IGcmExponentiator
 	{
 		void Init(byte[] x);
-		void ExponentiateX(long pow, byte[] output);
-	}
+        void ExponentiateX(long pow, byte[] output);
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        void ExponentiateX(long pow, Span<byte> output);
+#endif
+    }
 }

--- a/crypto/src/crypto/modes/gcm/Tables1kGcmExponentiator.cs
+++ b/crypto/src/crypto/modes/gcm/Tables1kGcmExponentiator.cs
@@ -22,7 +22,15 @@ namespace Org.BouncyCastle.Crypto.Modes.Gcm
             lookupPowX2.Add(y);
         }
 
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         public void ExponentiateX(long pow, byte[] output)
+        {
+            ExponentiateX(pow, output.AsSpan());
+        }
+        public void ExponentiateX(long pow, Span<byte> output)
+#else
+        public void ExponentiateX(long pow, byte[] output)
+#endif
         {
             GcmUtilities.FieldElement y;
             GcmUtilities.One(out y);

--- a/crypto/src/tls/DtlsRecordLayer.cs
+++ b/crypto/src/tls/DtlsRecordLayer.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
+#endif
 using System.Diagnostics;
 using System.IO;
 using System.Net.Sockets;
@@ -388,59 +391,70 @@ namespace Org.BouncyCastle.Tls
             Timeout timeout = Timeout.ForWaitMillis(waitMillis, currentTimeMillis);
             byte[] record = null;
 
-            while (waitMillis >= 0)
+            try
             {
-                if (null != m_retransmitTimeout && m_retransmitTimeout.RemainingMillis(currentTimeMillis) < 1)
+                while (waitMillis >= 0)
                 {
-                    m_retransmit = null;
-                    m_retransmitEpoch = null;
-                    m_retransmitTimeout = null;
+                    if (null != m_retransmitTimeout && m_retransmitTimeout.RemainingMillis(currentTimeMillis) < 1)
+                    {
+                        m_retransmit = null;
+                        m_retransmitEpoch = null;
+                        m_retransmitTimeout = null;
+                    }
+
+                    if (Timeout.HasExpired(m_heartbeatTimeout, currentTimeMillis))
+                    {
+                        if (null != m_heartbeatInFlight)
+                            throw new TlsTimeoutException("Heartbeat timed out");
+
+                        this.m_heartbeatInFlight = HeartbeatMessage.Create(m_context,
+                            HeartbeatMessageType.heartbeat_request, m_heartbeat.GeneratePayload());
+                        this.m_heartbeatTimeout = new Timeout(m_heartbeat.TimeoutMillis, currentTimeMillis);
+
+                        this.m_heartbeatResendMillis = TlsUtilities.GetHandshakeResendTimeMillis(m_peer);
+                        this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
+
+                        SendHeartbeatMessage(m_heartbeatInFlight);
+                    }
+                    else if (Timeout.HasExpired(m_heartbeatResendTimeout, currentTimeMillis))
+                    {
+                        this.m_heartbeatResendMillis = DtlsReliableHandshake.BackOff(m_heartbeatResendMillis);
+                        this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
+
+                        SendHeartbeatMessage(m_heartbeatInFlight);
+                    }
+
+                    waitMillis = Timeout.ConstrainWaitMillis(waitMillis, m_heartbeatTimeout, currentTimeMillis);
+                    waitMillis = Timeout.ConstrainWaitMillis(waitMillis, m_heartbeatResendTimeout, currentTimeMillis);
+
+                    // NOTE: Guard against bad logic giving a negative value 
+                    if (waitMillis < 0)
+                    {
+                        waitMillis = 1;
+                    }
+
+                    int receiveLimit = m_transport.GetReceiveLimit();
+                    if (null == record || record.Length < receiveLimit)
+                    {
+                        // record = new byte[receiveLimit];
+                        if (record is not null)
+                            ArrayPool<byte>.Shared.Return(record);
+                        record = ArrayPool<byte>.Shared.Rent(receiveLimit);
+                    }
+
+                    int received = ReceiveRecord(record, 0, receiveLimit, waitMillis);
+                    int processed = ProcessRecord(received, record, buffer, recordCallback);
+                    if (processed >= 0)
+                        return processed;
+
+                    currentTimeMillis = DateTimeUtilities.CurrentUnixMs();
+                    waitMillis = Timeout.GetWaitMillis(timeout, currentTimeMillis);
                 }
-
-                if (Timeout.HasExpired(m_heartbeatTimeout, currentTimeMillis))
-                {
-                    if (null != m_heartbeatInFlight)
-                        throw new TlsTimeoutException("Heartbeat timed out");
-
-                    this.m_heartbeatInFlight = HeartbeatMessage.Create(m_context,
-                        HeartbeatMessageType.heartbeat_request, m_heartbeat.GeneratePayload());
-                    this.m_heartbeatTimeout = new Timeout(m_heartbeat.TimeoutMillis, currentTimeMillis);
-
-                    this.m_heartbeatResendMillis = TlsUtilities.GetHandshakeResendTimeMillis(m_peer);
-                    this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
-
-                    SendHeartbeatMessage(m_heartbeatInFlight);
-                }
-                else if (Timeout.HasExpired(m_heartbeatResendTimeout, currentTimeMillis))
-                {
-                    this.m_heartbeatResendMillis = DtlsReliableHandshake.BackOff(m_heartbeatResendMillis);
-                    this.m_heartbeatResendTimeout = new Timeout(m_heartbeatResendMillis, currentTimeMillis);
-
-                    SendHeartbeatMessage(m_heartbeatInFlight);
-                }
-
-                waitMillis = Timeout.ConstrainWaitMillis(waitMillis, m_heartbeatTimeout, currentTimeMillis);
-                waitMillis = Timeout.ConstrainWaitMillis(waitMillis, m_heartbeatResendTimeout, currentTimeMillis);
-
-                // NOTE: Guard against bad logic giving a negative value 
-                if (waitMillis < 0)
-                {
-                    waitMillis = 1;
-                }
-
-                int receiveLimit = m_transport.GetReceiveLimit();
-                if (null == record || record.Length < receiveLimit)
-                {
-                    record = new byte[receiveLimit];
-                }
-
-                int received = ReceiveRecord(record, 0, receiveLimit, waitMillis);
-                int processed = ProcessRecord(received, record, buffer, recordCallback);
-                if (processed >= 0)
-                    return processed;
-
-                currentTimeMillis = DateTimeUtilities.CurrentUnixMs();
-                waitMillis = Timeout.GetWaitMillis(timeout, currentTimeMillis);
+            }
+            finally
+            {
+                if (record is not null)
+                    ArrayPool<byte>.Shared.Return(record);
             }
 
             return -1;
@@ -1135,8 +1149,12 @@ namespace Org.BouncyCastle.Tls
                 int recordHeaderLength = m_writeEpoch.RecordHeaderLengthWrite;
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-                TlsEncodeResult encoded = m_writeEpoch.Cipher.EncodePlaintext(macSequenceNumber, contentType,
-                    recordVersion, recordHeaderLength, buffer);
+                using var encoded = m_writeEpoch.Cipher.EncodePlaintext(macSequenceNumber, contentType,
+                    recordVersion, recordHeaderLength, buffer
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                    , ArrayPool<byte>.Shared
+#endif
+                );
 #else
                 TlsEncodeResult encoded = m_writeEpoch.Cipher.EncodePlaintext(macSequenceNumber, contentType,
                     recordVersion, recordHeaderLength, buf, off, len);

--- a/crypto/src/tls/RecordStream.cs
+++ b/crypto/src/tls/RecordStream.cs
@@ -293,7 +293,7 @@ namespace Org.BouncyCastle.Tls
             long seqNo = m_writeSeqNo.NextValue(AlertDescription.internal_error);
             ProtocolVersion recordVersion = m_writeVersion;
 
-            TlsEncodeResult encoded = m_writeCipher.EncodePlaintext(seqNo, contentType, recordVersion,
+            using var encoded = m_writeCipher.EncodePlaintext(seqNo, contentType, recordVersion,
                 RecordFormat.FragmentOffset, plaintext, plaintextOffset, plaintextLength);
 
             int ciphertextLength = encoded.len - RecordFormat.FragmentOffset;
@@ -340,8 +340,12 @@ namespace Org.BouncyCastle.Tls
             long seqNo = m_writeSeqNo.NextValue(AlertDescription.internal_error);
             ProtocolVersion recordVersion = m_writeVersion;
 
-            TlsEncodeResult encoded = m_writeCipher.EncodePlaintext(seqNo, contentType, recordVersion,
-                RecordFormat.FragmentOffset, plaintext);
+            using var encoded = m_writeCipher.EncodePlaintext(seqNo, contentType, recordVersion,
+                RecordFormat.FragmentOffset, plaintext
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+                , System.Buffers.ArrayPool<byte>.Shared
+#endif
+            );
 
             int ciphertextLength = encoded.len - RecordFormat.FragmentOffset;
             TlsUtilities.CheckUint16(ciphertextLength);

--- a/crypto/src/tls/crypto/TlsCipher.cs
+++ b/crypto/src/tls/crypto/TlsCipher.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
+#endif
 using System.IO;
 
 namespace Org.BouncyCastle.Tls.Crypto
@@ -44,7 +47,7 @@ namespace Org.BouncyCastle.Tls.Crypto
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         // TODO[api] Add a parameter for how much (D)TLSInnerPlaintext padding to add
         TlsEncodeResult EncodePlaintext(long seqNo, short contentType, ProtocolVersion recordVersion,
-            int headerAllocation, ReadOnlySpan<byte> plaintext);
+            int headerAllocation, ReadOnlySpan<byte> plaintext, ArrayPool<byte> pool = null);
 #endif
 
         /// <summary>Decode the passed in ciphertext using the current bulk cipher.</summary>

--- a/crypto/src/tls/crypto/TlsEncodeResult.cs
+++ b/crypto/src/tls/crypto/TlsEncodeResult.cs
@@ -1,19 +1,45 @@
-﻿using System;
+﻿#nullable enable
+
+using System;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+using System.Buffers;
+#endif
+using System.Threading;
 
 namespace Org.BouncyCastle.Tls.Crypto
 {
-    public sealed class TlsEncodeResult
+    public struct TlsEncodeResult: IDisposable
     {
-        public readonly byte[] buf;
+        public byte[] buf;
         public readonly int off, len;
         public readonly short recordType;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        public readonly ArrayPool<byte>? pool;
+#endif
 
-        public TlsEncodeResult(byte[] buf, int off, int len, short recordType)
-        {
+        public TlsEncodeResult(byte[] buf, int off, int len, short recordType
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            , ArrayPool<byte>? pool = null
+#endif
+            ) {
             this.buf = buf;
             this.off = off;
             this.len = len;
             this.recordType = recordType;
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            this.pool = pool;
+#endif
+        }
+
+        public void Dispose()
+        {
+            byte[]? killBuf = Interlocked.Exchange(ref this.buf, null!);
+#if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+            if (killBuf is not null)
+            {
+                this.pool?.Return(this.buf);
+            }
+#endif
         }
     }
 }

--- a/crypto/src/tls/crypto/TlsNullNullCipher.cs
+++ b/crypto/src/tls/crypto/TlsNullNullCipher.cs
@@ -33,11 +33,13 @@ namespace Org.BouncyCastle.Tls.Crypto
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
         public TlsEncodeResult EncodePlaintext(long seqNo, short contentType, ProtocolVersion recordVersion,
-            int headerAllocation, ReadOnlySpan<byte> plaintext)
+            int headerAllocation, ReadOnlySpan<byte> plaintext,
+            System.Buffers.ArrayPool<byte> pool = null)
         {
-            byte[] result = new byte[headerAllocation + plaintext.Length];
+            int bufferSize = headerAllocation + plaintext.Length;
+            byte[] result = pool?.Rent(bufferSize) ?? new byte[bufferSize];
             plaintext.CopyTo(result.AsSpan(headerAllocation));
-            return new TlsEncodeResult(result, 0, result.Length, contentType);
+            return new TlsEncodeResult(result, 0, bufferSize, contentType, pool);
         }
 #endif
 


### PR DESCRIPTION
Cumulatively in my stress test for SIPSorcery data channels this reduces amount of bytes allocated by BouncyCastle internally from 1.8GB down to 0.6GB in a 1 minute run and together with SIPSorcery fixes brings GC runs from multiple times per second down to a run every 10 seconds or so.