### PR TITLE
FIx method Write(ReadOnlySpan<byte>) in LimitedBuffer

### DIFF
--- a/crypto/src/util/io/LimitedBuffer.cs
+++ b/crypto/src/util/io/LimitedBuffer.cs
@@ -47,6 +47,7 @@ namespace Org.BouncyCastle.Utilities.IO
         public override void Write(ReadOnlySpan<byte> buffer)
         {
             buffer.CopyTo(m_buf.AsSpan(m_count));
+            m_count += buffer.Length;
         }
 #endif
 


### PR DESCRIPTION
Fix `LimitedBuffer.Write(ReadOnlySpan<byte>)` method.

The error manifested as `System.InvalidOperationException: Incorrect prehash size` when using RSA PSS.

Code for replication fixed bug:
```cs
SecureRandom secureRandom = new SecureRandom();
Org.BouncyCastle.Crypto.Generators.RsaKeyPairGenerator generator = new Org.BouncyCastle.Crypto.Generators.RsaKeyPairGenerator();
generator.Init(new RsaKeyGenerationParameters(new Org.BouncyCastle.Math.BigInteger(1, new byte[] { 1, 0, 1 }),
    secureRandom,
    2048,
    100));

var keyPair = generator.GenerateKeyPair();

IDigest contentDigest = new Sha256Digest();
IDigest mgfDigest = new Sha256Digest();

ISigner signer = PssSigner.CreateRawSigner(new RsaBlindedEngine(),
     contentDigest,
     mgfDigest,
     32,
     PssSigner.TrailerImplicit);

byte[] hashToSign = new byte[32];
secureRandom.NextBytes(hashToSign);

signer.Init(true, keyPair.Private);
signer.BlockUpdate(hashToSign);
byte[] signature = signer.GenerateSignature();
```