### PR TITLE
Refine FindTestResource

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,6 @@
 <Project>
   <PropertyGroup>
     <GitVersionBaseDirectory>$(MSBuildThisFileDirectory)</GitVersionBaseDirectory>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
 </Project>

--- a/crypto/test/src/pqc/crypto/test/MLKemTest.cs
+++ b/crypto/test/src/pqc/crypto/test/MLKemTest.cs
@@ -39,7 +39,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.Tests
             {
                 string name = files[fileIndex];
                 // System.Out.WriteLine("testing: " + name);
-                var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
+                using var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
 
                 string line = null;
                 Dictionary<string, string> buf = new Dictionary<string, string>();
@@ -105,7 +105,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.Tests
             {
                 string name = files[fileIndex];
                 // System.Out.WriteLine("testing: " + name);
-                var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
+                using var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
                 string line = null;
                 Dictionary<string, string> buf = new Dictionary<string, string>();
                 while ((line = src.ReadLine()) != null)
@@ -173,7 +173,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.Tests
             {
                 string name = files[fileIndex];
                 // System.Out.WriteLine("testing: " + name);
-                var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
+                using var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/acvp", name));
                 string line = null;
                 Dictionary<string, string> buf = new Dictionary<string, string>();
                 while ((line = src.ReadLine()) != null)
@@ -235,7 +235,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.Tests
             {
                 string name = files[fileIndex];
                 // System.Out.WriteLine("testing: " + name);
-                var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/modulus", name));
+                using var src = new StreamReader(SimpleTest.FindTestResource("pqc/crypto/kyber/modulus", name));
                 string line = null;
                 while ((line = src.ReadLine()) != null)
                 {

--- a/crypto/test/src/util/test/SimpleTest.cs
+++ b/crypto/test/src/util/test/SimpleTest.cs
@@ -138,23 +138,21 @@ namespace Org.BouncyCastle.Utilities.Test
 
         internal static Stream FindTestResource(string homeDir, string fileName)
         {
-            string wrkDirName = Directory.GetCurrentDirectory();
-            string separator = Path.DirectorySeparatorChar.ToString();
-            DirectoryInfo wrkDir = new DirectoryInfo(wrkDirName);
-            DirectoryInfo dataDir = new DirectoryInfo(Path.Combine(wrkDir.FullName, DataDirName));
+            string wrkDirPath = Directory.GetCurrentDirectory();
+            string dataDirPath;
 
-            while (!dataDir.Exists && wrkDirName.Length > 1)
+            while (!Directory.Exists(dataDirPath = Path.Combine(wrkDirPath, DataDirName)))
             {
-                wrkDirName = wrkDirName.Substring(0, wrkDirName.LastIndexOf(separator));
-                wrkDir = new DirectoryInfo(wrkDirName);
-                dataDir = new DirectoryInfo(Path.Combine(wrkDir.FullName, DataDirName));
+                wrkDirPath = Path.GetDirectoryName(wrkDirPath);
+
+                if (wrkDirPath is null)
+                {
+                    throw new DirectoryNotFoundException("Test data directory " + DataDirName + " not found." + NewLine +
+                        "Test data available from: https://github.com/bcgit/bc-test-data.git");
+                }
             }
 
-            if (!dataDir.Exists)
-                throw new FileNotFoundException("Test data directory " + DataDirName + " not found." + NewLine +
-                    "Test data available from: https://github.com/bcgit/bc-test-data.git");
-
-            return File.OpenRead(Path.Combine(dataDir.FullName, homeDir + separator + fileName));
+            return File.OpenRead(Path.Combine(dataDirPath, homeDir, fileName));
         }
     }
 }


### PR DESCRIPTION


## Describe your changes

This was failing on the Substring call with:

"System.ArgumentOutOfRangeException : Length cannot be less than zero."

Now it is:

"System.IO.DirectoryNotFoundException : Test data directory bc-test-data not found.
Test data available from: https://github.com/bcgit/bc-test-data.git"

Also add "using" declarations on the returned streams. (This requires declaring a more recent language version in the project)

## How has this been tested?

<!--- If relevant, please describe any tests you ran to verify your changes. -->
Unit tests before and after

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
