### PR TITLE
GetBytes used for non-octet aligned signatures

### DIFF
--- a/crypto/src/x509/X509Utilities.cs
+++ b/crypto/src/x509/X509Utilities.cs
@@ -279,7 +279,7 @@ namespace Org.BouncyCastle.X509
             var result = CalculateResult(verifierFactory.CreateCalculator(), asn1Encodable);
 
 			// TODO[api] Use GetOctetsSpan() once IsVerified(ReadOnlySpan<byte>) is available
-			return result.IsVerified(signature.GetOctets());
+			return result.IsVerified(signature.GetBytes());
         }
 
         internal static Asn1TaggedObject TrimExtensions(int tagNo, X509Extensions exts)


### PR DESCRIPTION
Openssl signatures are not octet aligned, and thus signature verification fails for signing requests, etc.
Is there a reason that octet aligned signatures are enforced?