### PR TITLE
SRTP_AES256 is added according draft-ietf-avt-dtls-srtp-00

### DIFF
--- a/crypto/src/tls/SrtpProtectionProfile.cs
+++ b/crypto/src/tls/SrtpProtectionProfile.cs
@@ -13,6 +13,12 @@ namespace Org.BouncyCastle.Tls
         public const int SRTP_NULL_HMAC_SHA1_32 = 0x0006;
 
         /*
+         * draft-ietf-avt-dtls-srtp-00 3.2.2
+         */
+        public const int SRTP_AES256_CM_HMAC_SHA1_80 = 0x0003;
+        public const int SRTP_AES256_CM_HMAC_SHA1_32 = 0x0004;
+        
+        /*
          * RFC 7714 14.2.
          */
         public const int SRTP_AEAD_AES_128_GCM = 0x0007;


### PR DESCRIPTION
## Describe your changes

SRTP_AES256 is added according draft-ietf-avt-dtls-srtp-00
Both SRTP_AES256_CM_HMAC_SHA1_80 and SRTP_AES256_CM_HMAC_SHA1_32 are widely used in SRTP
Only new items are added to the "Enum" Class

## How has this been tested?

Only new items are added to the "Enum" Class. I believe it has no effect 

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
