### PR TITLE
Added netstandard2.1 to the build targets

### DIFF
--- a/crypto/src/BouncyCastle.Crypto.csproj
+++ b/crypto/src/BouncyCastle.Crypto.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;netstandard2.0;net461</TargetFrameworks>
+    <TargetFrameworks>net8.0;net6.0;netstandard2.0;netstandard2.1;net461</TargetFrameworks>
     <RootNamespace>Org.BouncyCastle</RootNamespace>
     <AssemblyOriginatorKeyFile>..\..\BouncyCastle.NET.snk</AssemblyOriginatorKeyFile>
     <SignAssembly>true</SignAssembly>


### PR DESCRIPTION
## Describe your changes

<!--- Please describe your changes in detail. Include the motivation for the changes, e.g. what problem it solves or if it fixes a bug. -->

There are a number of APIs in BouncyCastle that are conditionally enabled (such as APIs that make use of `ReadOnlySpan<T>`) when `#if NETSTANDARD2_1_OR_GREATER` evaluates to `true`.

This causes issues if any library that references BouncyCastle targets netstandard2.1 (and would therefore build against the netstandard2.0 version of BC) if it is itself referenced by an app (or other library) that targets net6.0+, resulting in a "missing implementation" error.

Fixes issue #447 (at least in a practical sense)

## How has this been tested?

<!--- If relevant, please describe any tests you ran to verify your changes. -->

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [ ] I have performed a self-review of my code
- [ ] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
