### PR TITLE
Update MemoryMarshal.Write calls

### DIFF
--- a/crypto/src/crypto/digests/Blake2b_X86.cs
+++ b/crypto/src/crypto/digests/Blake2b_X86.cs
@@ -71,11 +71,16 @@ namespace Org.BouncyCastle.Crypto.Digests
             row1 = Avx2.Xor(row1, orig_1);
             row2 = Avx2.Xor(row2, orig_2);
 
-            MemoryMarshal.Write(hashBytes, ref row1);
-            MemoryMarshal.Write(hashBytes[32..], ref row2);
-        }
+#if NET8_0_OR_GREATER
+            MemoryMarshal.Write(hashBytes, in row1);
+            MemoryMarshal.Write(hashBytes[32..], in row2);
+#else
+			MemoryMarshal.Write( hashBytes, ref row1 );
+			MemoryMarshal.Write( hashBytes[ 32.. ], ref row2 );
+#endif
+		}
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
         private static void Perform12Rounds(ReadOnlySpan<byte> m, ref Vector256<ulong> row1, ref Vector256<ulong> row2, ref Vector256<ulong> row3, ref Vector256<ulong> row4)
         {
 #region Rounds

--- a/crypto/src/crypto/digests/Blake2s_X86.cs
+++ b/crypto/src/crypto/digests/Blake2s_X86.cs
@@ -71,8 +71,13 @@ namespace Org.BouncyCastle.Crypto.Digests
             row1 = Sse2.Xor(row1, orig_1);
             row2 = Sse2.Xor(row2, orig_2);
 
+#if NET8_0_OR_GREATER
+            MemoryMarshal.Write(hashBytes, in row1);
+            MemoryMarshal.Write(hashBytes[16..], in row2);
+#else
             MemoryMarshal.Write(hashBytes, ref row1);
             MemoryMarshal.Write(hashBytes[16..], ref row2);
+#endif
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]

--- a/crypto/src/crypto/digests/Haraka256_X86.cs
+++ b/crypto/src/crypto/digests/Haraka256_X86.cs
@@ -131,8 +131,12 @@ namespace Org.BouncyCastle.Crypto.Digests
         {
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(t, in s);
+#else
                 MemoryMarshal.Write(t, ref s);
-                return;
+#endif
+				return;
             }
 
             var u = s.AsUInt64();

--- a/crypto/src/crypto/digests/Haraka512_X86.cs
+++ b/crypto/src/crypto/digests/Haraka512_X86.cs
@@ -214,7 +214,11 @@ namespace Org.BouncyCastle.Crypto.Digests
         {
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(t, in s);
+#else
                 MemoryMarshal.Write(t, ref s);
+#endif
                 return;
             }
 
@@ -228,8 +232,12 @@ namespace Org.BouncyCastle.Crypto.Digests
         {
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( t, in s );
+#else
                 MemoryMarshal.Write(t, ref s);
-                return;
+#endif
+				return;
             }
 
             var u = s.AsUInt64();

--- a/crypto/src/crypto/engines/AesEngine_X86.cs
+++ b/crypto/src/crypto/engines/AesEngine_X86.cs
@@ -823,8 +823,12 @@ namespace Org.BouncyCastle.Crypto.Engines
         {
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( t, in s );
+#else
                 MemoryMarshal.Write(t, ref s);
-                return;
+#endif
+				return;
             }
 
             var u = s.AsUInt64();

--- a/crypto/src/crypto/engines/ChaCha7539Engine.cs
+++ b/crypto/src/crypto/engines/ChaCha7539Engine.cs
@@ -492,8 +492,12 @@ namespace Org.BouncyCastle.Crypto.Engines
 		{
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( t, in s );
+#else
                 MemoryMarshal.Write(t, ref s);
-                return;
+#endif
+				return;
             }
 
             var u = s.AsUInt64();
@@ -506,7 +510,11 @@ namespace Org.BouncyCastle.Crypto.Engines
 		{
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( t, in s );
+#else
                 MemoryMarshal.Write(t, ref s);
+#endif
 				return;
 			}
 

--- a/crypto/src/crypto/engines/ChaChaEngine.cs
+++ b/crypto/src/crypto/engines/ChaChaEngine.cs
@@ -228,7 +228,11 @@ namespace Org.BouncyCastle.Crypto.Engines
 		{
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( t, in s );
+#else
                 MemoryMarshal.Write(t, ref s);
+#endif
 				return;
 			}
 

--- a/crypto/src/crypto/engines/Salsa20Engine.cs
+++ b/crypto/src/crypto/engines/Salsa20Engine.cs
@@ -318,12 +318,19 @@ namespace Org.BouncyCastle.Crypto.Engines
                     var v3 = Sse41.Blend(u1, u3, 0x3C);
 
                     var X = MemoryMarshal.AsBytes(output[..16]);
+#if NET8_0_OR_GREATER
+                    MemoryMarshal.Write(X[0x00..0x10], in v0);
+                    MemoryMarshal.Write(X[0x10..0x20], in v1);
+                    MemoryMarshal.Write(X[0x20..0x30], in v2);
+                    MemoryMarshal.Write(X[0x30..0x40], in v3);
+#else
                     MemoryMarshal.Write(X[0x00..0x10], ref v0);
                     MemoryMarshal.Write(X[0x10..0x20], ref v1);
                     MemoryMarshal.Write(X[0x20..0x30], ref v2);
                     MemoryMarshal.Write(X[0x30..0x40], ref v3);
-                }
-                return;
+#endif
+				}
+				return;
 			}
 #endif
 

--- a/crypto/src/crypto/engines/SparkleEngine.cs
+++ b/crypto/src/crypto/engines/SparkleEngine.cs
@@ -1360,7 +1360,11 @@ namespace Org.BouncyCastle.Crypto.Engines
             var b = MemoryMarshal.AsBytes(t);
             if (Org.BouncyCastle.Runtime.Intrinsics.Vector.IsPackedLittleEndian)
             {
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(b, in s);
+#else
                 MemoryMarshal.Write(b, ref s);
+#endif
                 return;
             }
 
@@ -1369,5 +1373,5 @@ namespace Org.BouncyCastle.Crypto.Engines
             BinaryPrimitives.WriteUInt64LittleEndian(b[8..], u.GetElement(1));
         }
 #endif
-    }
-}
+			}
+		}

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -1105,13 +1105,18 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
                 MemoryMarshal.Write(output, ref t1);
                 MemoryMarshal.Write(S.AsSpan(), ref t2);
+#endif
             }
             else
 #endif
-            {
-                for (int i = 0; i < BlockSize; i += 4)
+				{
+					for (int i = 0; i < BlockSize; i += 4)
                 {
                     byte c0 = input[i + 0];
                     byte c1 = input[i + 1];
@@ -1148,13 +1153,18 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
                 MemoryMarshal.Write(output, ref t1);
                 MemoryMarshal.Write(S.AsSpan(), ref t2);
+#endif
             }
             else
 #endif
-            {
-                for (int i = 0; i < BlockSize; i += 4)
+				{
+					for (int i = 0; i < BlockSize; i += 4)
                 {
                     byte c0 = input[i + 0];
                     byte c1 = input[i + 1];
@@ -1189,13 +1199,18 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
                 MemoryMarshal.Write(output, ref t1);
                 MemoryMarshal.Write(S.AsSpan(), ref t2);
+#endif
             }
             else
 #endif
-            {
-                for (int i = 0; i < BlockSize; i += 4)
+				{
+					for (int i = 0; i < BlockSize; i += 4)
                 {
                     byte c0 = input[i + 0];
                     byte c1 = input[i + 1];
@@ -1249,10 +1264,17 @@ namespace Org.BouncyCastle.Crypto.Modes
                 var p2 = Sse2.Xor(c2, counters[2]);
                 var p3 = Sse2.Xor(c3, counters[3]);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in p0);
+                MemoryMarshal.Write(output[BlockSize..], in p1);
+                MemoryMarshal.Write(output[(BlockSize * 2)..], in p2);
+                MemoryMarshal.Write(output[(BlockSize * 3)..], in p3);
+#else
                 MemoryMarshal.Write(output, ref p0);
                 MemoryMarshal.Write(output[BlockSize..], ref p1);
                 MemoryMarshal.Write(output[(BlockSize * 2)..], ref p2);
                 MemoryMarshal.Write(output[(BlockSize * 3)..], ref p3);
+#endif
 
                 input = input[(BlockSize * 4)..];
                 output = output[(BlockSize * 4)..];
@@ -1285,11 +1307,15 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
 
             S128 = Ssse3.Shuffle(S128, ReverseBytesMask);
+#if NET8_0_OR_GREATER
+            MemoryMarshal.Write(S.AsSpan(), in S128);
+#else
             MemoryMarshal.Write(S.AsSpan(), ref S128);
+#endif
         }
 #endif
 
-        private void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
+		private void EncryptBlock(ReadOnlySpan<byte> input, Span<byte> output)
         {
             Span<byte> ctrBlock = stackalloc byte[BlockSize];
 
@@ -1305,10 +1331,14 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t1);
 
-                MemoryMarshal.Write(output, ref t1);
-                MemoryMarshal.Write(S.AsSpan(), ref t2);
-            }
-            else
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
+				MemoryMarshal.Write( output, ref t1 );
+				MemoryMarshal.Write( S.AsSpan(), ref t2 );
+#endif
+			} else
 #endif
             {
                 for (int i = 0; i < BlockSize; i += 4)
@@ -1348,10 +1378,14 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
                 MemoryMarshal.Write(output, ref t1);
                 MemoryMarshal.Write(S.AsSpan(), ref t2);
-            }
-            else
+#endif
+			} else
 #endif
             {
                 for (int i = 0; i < BlockSize; i += 4)
@@ -1389,13 +1423,18 @@ namespace Org.BouncyCastle.Crypto.Modes
                 t1 = Sse2.Xor(t1, t0);
                 t2 = Sse2.Xor(t2, t1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in t1);
+                MemoryMarshal.Write(S.AsSpan(), in t2);
+#else
                 MemoryMarshal.Write(output, ref t1);
                 MemoryMarshal.Write(S.AsSpan(), ref t2);
+#endif
             }
             else
 #endif
-            {
-                for (int i = 0; i < BlockSize; i += 4)
+				{
+					for (int i = 0; i < BlockSize; i += 4)
                 {
                     byte c0 = (byte)(ctrBlocks[i + 0] ^ input[i + 0]);
                     byte c1 = (byte)(ctrBlocks[i + 1] ^ input[i + 1]);
@@ -1446,10 +1485,17 @@ namespace Org.BouncyCastle.Crypto.Modes
                 var c2 = Sse2.Xor(p2, counters[2]);
                 var c3 = Sse2.Xor(p3, counters[3]);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(output, in c0);
+                MemoryMarshal.Write(output[BlockSize..], in c1);
+                MemoryMarshal.Write(output[(BlockSize * 2)..], in c2);
+                MemoryMarshal.Write(output[(BlockSize * 3)..], in c3);
+#else
                 MemoryMarshal.Write(output, ref c0);
                 MemoryMarshal.Write(output[BlockSize..], ref c1);
                 MemoryMarshal.Write(output[(BlockSize * 2)..], ref c2);
                 MemoryMarshal.Write(output[(BlockSize * 3)..], ref c3);
+#endif
 
                 input = input[(BlockSize * 4)..];
                 output = output[(BlockSize * 4)..];
@@ -1482,11 +1528,15 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
 
             S128 = Ssse3.Shuffle(S128, ReverseBytesMask);
+#if NET8_0_OR_GREATER
+            MemoryMarshal.Write(S.AsSpan(), in S128);
+#else
             MemoryMarshal.Write(S.AsSpan(), ref S128);
-        }
+#endif
+		}
 #endif
 
-        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+				[MethodImpl(MethodImplOptions.AggressiveInlining)]
         private void GetNextCtrBlock(Span<byte> block)
         {
             Pack.UInt32_To_BE(++counter32, counter, 12);

--- a/crypto/src/math/ec/custom/sec/SecT113Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT113Field.cs
@@ -302,17 +302,22 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z23 = Sse2.Xor(Z23, Sse2.ShiftRightLogical128BitLane(Z12, 8));
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
+#endif
                 return;
             }
 #endif
 
-            /*
-             * "Three-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
-             */
+				/*
+				 * "Three-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
+				 */
 
-            ulong f0 = x[0], f1 = x[1];
+				ulong f0 = x[0], f1 = x[1];
             f1  = ((f0 >> 57) ^ (f1 << 7)) & M57;
             f0 &= M57;
 

--- a/crypto/src/math/ec/custom/sec/SecT131Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT131Field.cs
@@ -349,18 +349,24 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z4_ = Sse2.Xor(Z4_, Sse2.ShiftRightLogical128BitLane(Z34, 8));
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
+#endif
+
                 zz[4] = Z4_.ToScalar();
                 return;
             }
 #endif
 
-            /*
-             * "Five-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
-             */
+				/*
+				 * "Five-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
+				 */
 
-            ulong f0 = x[0], f1 = x[1], f2 = x[2];
+				ulong f0 = x[0], f1 = x[1], f2 = x[2];
             f2  = ((f1 >> 24) ^ (f2 << 40)) & M44;
             f1  = ((f0 >> 44) ^ (f1 << 20)) & M44;
             f0 &= M44;

--- a/crypto/src/math/ec/custom/sec/SecT163Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT163Field.cs
@@ -360,18 +360,24 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z45 = Sse2.Xor(Z45, Sse2.ShiftRightLogical128BitLane(Z34, 8));
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+                MemoryMarshal.Write(zzBytes[0x20..0x30], in Z45);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
                 MemoryMarshal.Write(zzBytes[0x20..0x30], ref Z45);
+#endif
                 return;
             }
 #endif
 
-            /*
-             * "Five-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
-             */
+				/*
+				 * "Five-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
+				 */
 
-            ulong f0 = x[0], f1 = x[1], f2 = x[2];
+				ulong f0 = x[0], f1 = x[1], f2 = x[2];
             f2  = ((f1 >> 46) ^ (f2 << 18));
             f1  = ((f0 >> 55) ^ (f1 <<  9)) & M55;
             f0 &= M55;

--- a/crypto/src/math/ec/custom/sec/SecT233Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT233Field.cs
@@ -420,19 +420,26 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z45 = Sse2.Xor(Z45, K23);
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+                MemoryMarshal.Write(zzBytes[0x20..0x30], in Z45);
+                MemoryMarshal.Write(zzBytes[0x30..0x40], in Z67);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
                 MemoryMarshal.Write(zzBytes[0x20..0x30], ref Z45);
                 MemoryMarshal.Write(zzBytes[0x30..0x40], ref Z67);
+#endif
                 return;
             }
 #endif
 
-            /*
-             * "Two-level seven-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
-             */
+				/*
+				 * "Two-level seven-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
+				 */
 
-            Span<ulong> f = stackalloc ulong[4], g = stackalloc ulong[4];
+				Span<ulong> f = stackalloc ulong[4], g = stackalloc ulong[4];
             ImplExpand(x, f);
             ImplExpand(y, g);
 

--- a/crypto/src/math/ec/custom/sec/SecT239Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT239Field.cs
@@ -429,19 +429,26 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z45 = Sse2.Xor(Z45, K23);
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+                MemoryMarshal.Write(zzBytes[0x20..0x30], in Z45);
+                MemoryMarshal.Write(zzBytes[0x30..0x40], in Z67);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
                 MemoryMarshal.Write(zzBytes[0x20..0x30], ref Z45);
                 MemoryMarshal.Write(zzBytes[0x30..0x40], ref Z67);
+#endif
                 return;
             }
 #endif
 
-            /*
-             * "Two-level seven-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
-             */
+				/*
+				 * "Two-level seven-way recursion" as described in "Batch binary Edwards", Daniel J. Bernstein.
+				 */
 
-            Span<ulong> f = stackalloc ulong[4], g = stackalloc ulong[4];
+				Span<ulong> f = stackalloc ulong[4], g = stackalloc ulong[4];
             ImplExpand(x, f);
             ImplExpand(y, g);
 

--- a/crypto/src/math/ec/custom/sec/SecT283Field.cs
+++ b/crypto/src/math/ec/custom/sec/SecT283Field.cs
@@ -435,22 +435,30 @@ namespace Org.BouncyCastle.Math.EC.Custom.Sec
                 Z89 = Sse2.Xor(Z89, Sse2.ShiftRightLogical128BitLane(Z78, 8));
 
                 Span<byte> zzBytes = MemoryMarshal.AsBytes(zz);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(zzBytes[0x00..0x10], in Z01);
+                MemoryMarshal.Write(zzBytes[0x10..0x20], in Z23);
+                MemoryMarshal.Write(zzBytes[0x20..0x30], in Z45);
+                MemoryMarshal.Write(zzBytes[0x30..0x40], in Z67);
+                MemoryMarshal.Write(zzBytes[0x40..0x50], in Z89);
+#else
                 MemoryMarshal.Write(zzBytes[0x00..0x10], ref Z01);
                 MemoryMarshal.Write(zzBytes[0x10..0x20], ref Z23);
                 MemoryMarshal.Write(zzBytes[0x20..0x30], ref Z45);
                 MemoryMarshal.Write(zzBytes[0x30..0x40], ref Z67);
                 MemoryMarshal.Write(zzBytes[0x40..0x50], ref Z89);
+#endif
                 return;
             }
 #endif
 
-            /*
-             * Formula (17) from "Some New Results on Binary Polynomial Multiplication",
-             * Murat Cenk and M. Anwar Hasan.
-             * 
-             * The formula as given contained an error in the term t25, as noted below
-             */
-            ulong[] a = new ulong[5], b = new ulong[5];
+				/*
+				 * Formula (17) from "Some New Results on Binary Polynomial Multiplication",
+				 * Murat Cenk and M. Anwar Hasan.
+				 * 
+				 * The formula as given contained an error in the term t25, as noted below
+				 */
+				ulong[] a = new ulong[5], b = new ulong[5];
             ImplExpand(x, a);
             ImplExpand(y, b);
 

--- a/crypto/src/math/ec/rfc7748/X25519Field.cs
+++ b/crypto/src/math/ec/rfc7748/X25519Field.cs
@@ -74,7 +74,7 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
 #if NET8_0_OR_GREATER
                 MemoryMarshal.Write(Z, in R0);
 #else
-            `   MemoryMarshal.Write(Z, ref R0);
+                MemoryMarshal.Write(Z, ref R0);
 #endif
 
                 var X1 = MemoryMarshal.Read<Vector128<int>>(X[0x10..]);

--- a/crypto/src/math/ec/rfc7748/X25519Field.cs
+++ b/crypto/src/math/ec/rfc7748/X25519Field.cs
@@ -47,9 +47,13 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
 
                 var R0 = Avx2.Add(X0, Y0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z, in R0);
+#else
                 MemoryMarshal.Write(Z, ref R0);
+#endif
 
-                z[8] = x[8] + y[8];
+				z[ 8] = x[8] + y[8];
                 z[9] = x[9] + y[9];
 
                 return;
@@ -67,14 +71,21 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
 
                 var R0 = Sse2.Add(X0, Y0);
 
-                MemoryMarshal.Write(Z, ref R0);
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z, in R0);
+#else
+            `   MemoryMarshal.Write(Z, ref R0);
+#endif
 
                 var X1 = MemoryMarshal.Read<Vector128<int>>(X[0x10..]);
                 var Y1 = MemoryMarshal.Read<Vector128<int>>(Y[0x10..]);
 
                 var R1 = Sse2.Add(X1, Y1);
-
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x10..], in R1);
+#else
                 MemoryMarshal.Write(Z[0x10..], ref R1);
+#endif
 
                 z[8] = x[8] + y[8];
                 z[9] = x[9] + y[9];
@@ -83,8 +94,8 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
             }
 #endif
 
-            {
-                for (int i = 0; i < Size; ++i)
+				{
+					for (int i = 0; i < Size; ++i)
                 {
                     z[i] = x[i] + y[i];
                 }
@@ -121,8 +132,13 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
                 var RP0 = Avx2.Add(X0, Y0);
                 var RM0 = Avx2.Subtract(X0, Y0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(ZP, in RP0);
+                MemoryMarshal.Write(ZM, in RM0);
+#else
                 MemoryMarshal.Write(ZP, ref RP0);
                 MemoryMarshal.Write(ZM, ref RM0);
+#endif
 
                 int x8 = x[8], y8 = y[8];
                 zp[8] = x8 + y8;
@@ -149,17 +165,27 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
                 var RP0 = Sse2.Add(X0, Y0);
                 var RM0 = Sse2.Subtract(X0, Y0);
 
-                MemoryMarshal.Write(ZP, ref RP0);
+#if NET8_0_OR_GREATER
+				MemoryMarshal.Write( ZP, in RP0 );
+				MemoryMarshal.Write( ZM, in RM0 );
+#else
+				MemoryMarshal.Write(ZP, ref RP0);
                 MemoryMarshal.Write(ZM, ref RM0);
+#endif
 
-                var X1 = MemoryMarshal.Read<Vector128<int>>(X[0x10..]);
+				var X1 = MemoryMarshal.Read<Vector128<int>>(X[0x10..]);
                 var Y1 = MemoryMarshal.Read<Vector128<int>>(Y[0x10..]);
 
                 var RP1 = Sse2.Add(X1, Y1);
                 var RM1 = Sse2.Subtract(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(ZP[0x10..], in RP1);
+                MemoryMarshal.Write(ZM[0x10..], in RM1);
+#else
                 MemoryMarshal.Write(ZP[0x10..], ref RP1);
                 MemoryMarshal.Write(ZM[0x10..], ref RM1);
+#endif
 
                 int x8 = x[8], y8 = y[8];
                 zp[8] = x8 + y8;
@@ -173,8 +199,8 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
             }
 #endif
 
-            {
-                for (int i = 0; i < Size; ++i)
+				{
+					for (int i = 0; i < Size; ++i)
                 {
                     int xi = x[i], yi = y[i];
                     zp[i] = xi + yi;
@@ -1117,7 +1143,11 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
 
                 var R0 = Avx2.Subtract(X0, Y0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z, in R0);
+#else
                 MemoryMarshal.Write(Z, ref R0);
+#endif
 
                 z[8] = x[8] - y[8];
                 z[9] = x[9] - y[9];
@@ -1137,14 +1167,23 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
 
                 var R0 = Sse2.Subtract(X0, Y0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z, in R0);
+#else
                 MemoryMarshal.Write(Z, ref R0);
+#endif
 
                 var X1 = MemoryMarshal.Read<Vector128<int>>(X[0x10..]);
                 var Y1 = MemoryMarshal.Read<Vector128<int>>(Y[0x10..]);
 
                 var R1 = Sse2.Subtract(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x10..], in R1);
+#else
                 MemoryMarshal.Write(Z[0x10..], ref R1);
+#endif
+
 
                 z[8] = x[8] - y[8];
                 z[9] = x[9] - y[9];
@@ -1153,8 +1192,8 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
             }
 #endif
 
-            {
-                for (int i = 0; i < Size; ++i)
+				{
+					for (int i = 0; i < Size; ++i)
                 {
                     z[i] = x[i] - y[i];
                 }

--- a/crypto/src/math/ec/rfc7748/X448Field.cs
+++ b/crypto/src/math/ec/rfc7748/X448Field.cs
@@ -1513,14 +1513,19 @@ namespace Org.BouncyCastle.Math.EC.Rfc7748
                     Z1 = Avx2.Add(Z1, Avx2.And(C0, MaskScalar));
                 }
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
+#endif
 
                 return;
             }
 #endif
 
-            uint x0 = x[0], x1 = x[1], x2 = x[2], x3 = x[3], x4 = x[4], x5 = x[5], x6 = x[6], x7 = x[7];
+				uint x0 = x[0], x1 = x[1], x2 = x[2], x3 = x[3], x4 = x[4], x5 = x[5], x6 = x[6], x7 = x[7];
             uint x8 = x[8], x9 = x[9], x10 = x[10], x11 = x[11], x12 = x[12], x13 = x[13], x14 = x[14], x15 = x[15];
             uint y0 = y[0], y1 = y[1], y2 = y[2], y3 = y[3], y4 = y[4], y5 = y[5], y6 = y[6], y7 = y[7];
             uint y8 = y[8], y9 = y[9], y10 = y[10], y11 = y[11], y12 = y[12], y13 = y[13], y14 = y[14], y15 = y[15];

--- a/crypto/src/math/raw/Nat256.cs
+++ b/crypto/src/math/raw/Nat256.cs
@@ -1877,7 +1877,11 @@ namespace Org.BouncyCastle.Math.Raw
 
                 var Z0 = Avx2.Xor(X0, Y0);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
+#endif
                 return;
             }
 
@@ -1897,13 +1901,18 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z0 = Sse2.Xor(X0, Y0);
                 var Z1 = Sse2.Xor(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
+#endif
                 return;
             }
 #endif
 
-            for (int i = 0; i < 8; i += 4)
+				for ( int i = 0; i < 8; i += 4)
             {
                 z[i + 0] = x[i + 0] ^ y[i + 0];
                 z[i + 1] = x[i + 1] ^ y[i + 1];

--- a/crypto/src/math/raw/Nat512.cs
+++ b/crypto/src/math/raw/Nat512.cs
@@ -98,8 +98,14 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z0 = Avx2.Xor(X0, Y0);
                 var Z1 = Avx2.Xor(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
+#endif
+
                 return;
             }
 
@@ -125,15 +131,22 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z2 = Sse2.Xor(X2, Y2);
                 var Z3 = Sse2.Xor(X3, Y3);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
-                return;
+#endif
+				return;
             }
 #endif
 
-            for (int i = 0; i < 16; i += 4)
+				for ( int i = 0; i < 16; i += 4)
             {
                 z[i + 0] = x[i + 0] ^ y[i + 0];
                 z[i + 1] = x[i + 1] ^ y[i + 1];
@@ -193,9 +206,14 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z0 = Avx2.Xor(X0, Y0);
                 var Z1 = Avx2.Xor(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
-                return;
+#endif
+				return;
             }
 
             if (Org.BouncyCastle.Runtime.Intrinsics.X86.Sse2.IsEnabled &&
@@ -220,15 +238,22 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z2 = Sse2.Xor(X2, Y2);
                 var Z3 = Sse2.Xor(X3, Y3);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
+#endif
                 return;
             }
 #endif
 
-            for (int i = 0; i < 8; i += 4)
+				for ( int i = 0; i < 8; i += 4)
             {
                 z[i + 0] = x[i + 0] ^ y[i + 0];
                 z[i + 1] = x[i + 1] ^ y[i + 1];
@@ -291,9 +316,14 @@ namespace Org.BouncyCastle.Math.Raw
                 Z0 = Avx2.Xor(Z0, Avx2.Xor(X0, Y0));
                 Z1 = Avx2.Xor(Z1, Avx2.Xor(X1, Y1));
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
-                return;
+#endif
+				return;
             }
 
             if (Org.BouncyCastle.Runtime.Intrinsics.X86.Sse2.IsEnabled &&
@@ -323,15 +353,22 @@ namespace Org.BouncyCastle.Math.Raw
                 Z2 = Sse2.Xor(Z2, Sse2.Xor(X2, Y2));
                 Z3 = Sse2.Xor(Z3, Sse2.Xor(X3, Y3));
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
+#endif
                 return;
             }
 #endif
 
-            for (int i = 0; i < 16; i += 4)
+				for ( int i = 0; i < 16; i += 4)
             {
                 z[i + 0] ^= x[i + 0] ^ y[i + 0];
                 z[i + 1] ^= x[i + 1] ^ y[i + 1];
@@ -394,9 +431,14 @@ namespace Org.BouncyCastle.Math.Raw
                 Z0 = Avx2.Xor(Z0, Avx2.Xor(X0, Y0));
                 Z1 = Avx2.Xor(Z1, Avx2.Xor(X1, Y1));
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
-                return;
+#endif
+				return;
             }
 
             if (Org.BouncyCastle.Runtime.Intrinsics.X86.Sse2.IsEnabled &&
@@ -426,11 +468,18 @@ namespace Org.BouncyCastle.Math.Raw
                 Z2 = Sse2.Xor(Z2, Sse2.Xor(X2, Y2));
                 Z3 = Sse2.Xor(Z3, Sse2.Xor(X3, Y3));
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
-                return;
+#endif
+				return;
             }
 #endif
 
@@ -493,8 +542,13 @@ namespace Org.BouncyCastle.Math.Raw
                 Z0 = Avx2.Xor(Z0, X0);
                 Z1 = Avx2.Xor(Z1, X1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
+#endif
                 return;
             }
 
@@ -519,15 +573,23 @@ namespace Org.BouncyCastle.Math.Raw
                 Z2 = Sse2.Xor(Z2, X2);
                 Z3 = Sse2.Xor(Z3, X3);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
+#endif
+
                 return;
             }
 #endif
 
-            for (int i = 0; i < 16; i += 4)
+				for ( int i = 0; i < 16; i += 4)
             {
                 z[i + 0] ^= x[i + 0];
                 z[i + 1] ^= x[i + 1];
@@ -586,8 +648,13 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z0 = Avx2.Xor(X0, Y0);
                 var Z1 = Avx2.Xor(X1, Y1);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x20], in Z0);
+                MemoryMarshal.Write(Z[0x20..0x40], in Z1);
+#else
                 MemoryMarshal.Write(Z[0x00..0x20], ref Z0);
                 MemoryMarshal.Write(Z[0x20..0x40], ref Z1);
+#endif
                 return;
             }
 
@@ -612,15 +679,23 @@ namespace Org.BouncyCastle.Math.Raw
                 var Z2 = Sse2.Xor(X2, Y2);
                 var Z3 = Sse2.Xor(X3, Y3);
 
+#if NET8_0_OR_GREATER
+                MemoryMarshal.Write(Z[0x00..0x10], in Z0);
+                MemoryMarshal.Write(Z[0x10..0x20], in Z1);
+                MemoryMarshal.Write(Z[0x20..0x30], in Z2);
+                MemoryMarshal.Write(Z[0x30..0x40], in Z3);
+#else
                 MemoryMarshal.Write(Z[0x00..0x10], ref Z0);
                 MemoryMarshal.Write(Z[0x10..0x20], ref Z1);
                 MemoryMarshal.Write(Z[0x20..0x30], ref Z2);
                 MemoryMarshal.Write(Z[0x30..0x40], ref Z3);
+#endif
+
                 return;
             }
 #endif
 
-            for (int i = 0; i < 8; i += 4)
+				for ( int i = 0; i < 8; i += 4)
             {
                 z[i + 0] ^= x[i + 0];
                 z[i + 1] ^= x[i + 1];

--- a/crypto/src/pqc/crypto/cmce/CmceEngine.cs
+++ b/crypto/src/pqc/crypto/cmce/CmceEngine.cs
@@ -1527,7 +1527,11 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
                             ulong t0 = MemoryMarshal.Read<ulong>(mat_k.AsSpan(c));
                             ulong t1 = MemoryMarshal.Read<ulong>(mat_row.AsSpan(c));
                             t1 ^= t0 & mask64;
+#if NET8_0_OR_GREATER
+                            MemoryMarshal.Write(mat_row.AsSpan(c), in t1);
+#else
                             MemoryMarshal.Write(mat_row.AsSpan(c), ref t1);
+#endif
                             c += 8;
                         }
                     }
@@ -1545,8 +1549,8 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
                         }
                     }
 #endif
-                    {
-                        byte maskByte = (byte)-mask;
+							{
+								byte maskByte = (byte)-mask;
                         while (c < SYS_N / 8)
                         {
                             mat_row[c] ^= (byte)(mat_k[c] & maskByte);
@@ -1594,7 +1598,11 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
                                 ulong t0 = MemoryMarshal.Read<ulong>(mat_row.AsSpan(c));
                                 ulong t1 = MemoryMarshal.Read<ulong>(mat_k.AsSpan(c));
                                 t1 ^= t0 & mask64;
+#if NET8_0_OR_GREATER
+                                MemoryMarshal.Write(mat_k.AsSpan(c), in t1);
+#else
                                 MemoryMarshal.Write(mat_k.AsSpan(c), ref t1);
+#endif
                                 c += 8;
                             }
                         }
@@ -1612,8 +1620,8 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
                             }
                         }
 #endif
-                        {
-                            byte maskByte = (byte)-mask;
+								{
+									byte maskByte = (byte)-mask;
                             while (c < SYS_N / 8)
                             {
                                 mat_k[c] ^= (byte)(mat_row[c] & maskByte);

--- a/crypto/src/util/Bytes.cs
+++ b/crypto/src/util/Bytes.cs
@@ -57,8 +57,12 @@ namespace Org.BouncyCastle.Utilities
                     ulong x64 = MemoryMarshal.Read<ulong>(x[i..]);
                     ulong y64 = MemoryMarshal.Read<ulong>(y[i..]);
                     ulong z64 = x64 ^ y64;
+#if NET8_0_OR_GREATER
+                    MemoryMarshal.Write(z[i..], in z64);
+#else
                     MemoryMarshal.Write(z[i..], ref z64);
-                    i += 8;
+#endif
+					i += 8;
                 }
             }
             {
@@ -117,7 +121,11 @@ namespace Org.BouncyCastle.Utilities
                     ulong x64 = MemoryMarshal.Read<ulong>(x[i..]);
                     ulong z64 = MemoryMarshal.Read<ulong>(z[i..]);
                     z64 ^= x64;
+#if NET8_0_OR_GREATER
+                    MemoryMarshal.Write(z[i..], in z64);
+#else
                     MemoryMarshal.Write(z[i..], ref z64);
+#endif
                     i += 8;
                 }
             }
@@ -130,5 +138,5 @@ namespace Org.BouncyCastle.Utilities
             }
         }
 #endif
-    }
-}
+				}
+			}


### PR DESCRIPTION
## Describe your changes

Update MemoryMarshal.Write calls to declare the 'value' parameter as IN not REF in net8+ compilations.  MS changed the semantics of the function in net8+ releases.

## How has this been tested?

All tests of the included test project passed w/o error.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../../CONTRIBUTING.md).
