### PR TITLE
Expose the S2K iteration count when symmetrically encrypting with OpenPGP

### DIFF
--- a/crypto/src/openpgp/PgpEncryptedDataGenerator.cs
+++ b/crypto/src/openpgp/PgpEncryptedDataGenerator.cs
@@ -329,7 +329,37 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
         /// Conversion of the passphrase characters to bytes is performed using Convert.ToByte(), which is
         /// the historical behaviour of the library (1.7 and earlier).
         /// </remarks>
-        public void AddMethod(char[] passPhrase, HashAlgorithmTag s2kDigest, int itCount = 0x60)
+        public void AddMethod(char[] passPhrase, HashAlgorithmTag s2kDigest)
+        {
+            var rawPassPhrase = PgpUtilities.EncodePassPhrase(passPhrase, utf8: false);
+
+            DoAddMethod(rawPassPhrase, clearPassPhrase: true, s2kDigest, itCount: 0x60);
+        }
+
+        /// <summary>Add a PBE encryption method to the encrypted object.</summary>
+        /// <remarks>
+        /// The passphrase is encoded to bytes using UTF8 (Encoding.UTF8.GetBytes).
+        /// </remarks>
+        public void AddMethodUtf8(char[] passPhrase, HashAlgorithmTag s2kDigest)
+        {
+            var rawPassPhrase = PgpUtilities.EncodePassPhrase(passPhrase, utf8: true);
+
+            DoAddMethod(rawPassPhrase, clearPassPhrase: true, s2kDigest, itCount: 0x60);
+        }
+
+        /// <summary>Add a PBE encryption method to the encrypted object.</summary>
+        /// <remarks>
+        /// Allows the caller to handle the encoding of the passphrase to bytes.
+        /// </remarks>
+        public void AddMethodRaw(byte[] rawPassPhrase, HashAlgorithmTag s2kDigest) =>
+            DoAddMethod(rawPassPhrase, clearPassPhrase: false, s2kDigest, itCount: 0x60);
+
+        /// <summary>Add a PBE encryption method to the encrypted object.</summary>
+        /// <remarks>
+        /// Conversion of the passphrase characters to bytes is performed using Convert.ToByte(), which is
+        /// the historical behaviour of the library (1.7 and earlier).
+        /// </remarks>
+        public void AddMethod(char[] passPhrase, HashAlgorithmTag s2kDigest, int itCount)
         {
             if (itCount < 0x00 || itCount > 0xFF)
             {
@@ -345,7 +375,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
         /// <remarks>
         /// The passphrase is encoded to bytes using UTF8 (Encoding.UTF8.GetBytes).
         /// </remarks>
-        public void AddMethodUtf8(char[] passPhrase, HashAlgorithmTag s2kDigest, int itCount = 0x60)
+        public void AddMethodUtf8(char[] passPhrase, HashAlgorithmTag s2kDigest, int itCount)
         {
             if (itCount < 0x00 || itCount > 0xFF)
             {
@@ -361,7 +391,7 @@ namespace Org.BouncyCastle.Bcpg.OpenPgp
         /// <remarks>
         /// Allows the caller to handle the encoding of the passphrase to bytes.
         /// </remarks>
-        public void AddMethodRaw(byte[] rawPassPhrase, HashAlgorithmTag s2kDigest, int itCount = 0x60)
+        public void AddMethodRaw(byte[] rawPassPhrase, HashAlgorithmTag s2kDigest, int itCount)
         {
             if (itCount < 0x00 || itCount > 0xFF)
             {


### PR DESCRIPTION
## Describe your changes

The OpenPGP message format allows the number of S2K iterations to be specified when creating a symmetrically encrypted message. However, the ability to set this was not previously exposed via the BouncyCastle.Cryptography C# library and a default coded count of 0x60 (decimal 96) was always used, corresponding to 65536 cycles.

This change modifies the `AddMethod`, `AddMethodUtf8`, and `AddMethodRaw` methods of the `PgpEncryptedDataGenerator` class to allow passing in a coded S2K iteration count.

## How has this been tested?

A local build of the nuget package was performed and consumed by a dependent application, which successfully made use of the now exposed S2K cycle parameter when creating a symmetrically encrypted PGP message. The cycle count passed in was confirmed to be respected using `gpg --list-packets` on the encrypted message.

All non-explicit automated tests are passing for the following targets: net461, net472, net6.0, netcoreapp3.1

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

