### PR TITLE
Fixes Zlib compression issues.

### DIFF
--- a/crypto/src/util/zlib/ZInputStream.cs
+++ b/crypto/src/util/zlib/ZInputStream.cs
@@ -51,7 +51,7 @@ namespace Org.BouncyCastle.Utilities.Zlib
             return z;
         }
 
-        private const int BufferSize = 4096;
+        private const int BufferSize = 512;
 
         protected ZStream z;
         protected int flushLevel = JZlib.Z_NO_FLUSH;
@@ -186,8 +186,6 @@ namespace Org.BouncyCastle.Utilities.Zlib
                 if (nomoreinput && err == JZlib.Z_BUF_ERROR)
                     return 0;
                 if (err != JZlib.Z_OK && err != JZlib.Z_STREAM_END)
-                    // TODO
-                    //throw new ZStreamException((compress ? "de" : "in") + "flating: " + z.msg);
                     throw new IOException((compress ? "de" : "in") + "flating: " + z.msg);
                 if ((nomoreinput || err == JZlib.Z_STREAM_END) && z.avail_out == count)
                     return 0;

--- a/crypto/src/util/zlib/ZOutputStream.cs
+++ b/crypto/src/util/zlib/ZOutputStream.cs
@@ -169,19 +169,18 @@ namespace Org.BouncyCastle.Utilities.Zlib
 
         public virtual void Finish()
         {
+            int err;
             do
             {
                 z.next_out = buf;
                 z.next_out_index = 0;
                 z.avail_out = buf.Length;
 
-                int err = compress
+                err = compress
                     ? z.deflate(JZlib.Z_FINISH)
                     : z.inflate(JZlib.Z_FINISH);
 
                 if (err != JZlib.Z_STREAM_END && err != JZlib.Z_OK)
-                    // TODO
-                    //throw new ZStreamException((compress?"de":"in")+"flating: "+z.msg);
                     throw new IOException((compress ? "de" : "in") + "flating: " + z.msg);
 
                 int count = buf.Length - z.avail_out;
@@ -190,7 +189,7 @@ namespace Org.BouncyCastle.Utilities.Zlib
                     output.Write(buf, 0, count);
                 }
             }
-            while (z.avail_in > 0 || z.avail_out == 0);
+            while ((z.avail_in > 0 || z.avail_out == 0) && err == JZlib.Z_OK);
 
             Flush();
         }
@@ -227,24 +226,23 @@ namespace Org.BouncyCastle.Utilities.Zlib
             z.next_in_index = offset;
             z.avail_in = count;
 
+            int err;
             do
             {
                 z.next_out = buf;
                 z.next_out_index = 0;
                 z.avail_out = buf.Length;
 
-                int err = compress
+                err = compress
                     ? z.deflate(flushLevel)
                     : z.inflate(flushLevel);
 
-                if (err != JZlib.Z_OK)
-                    // TODO
-                    //throw new ZStreamException((compress ? "de" : "in") + "flating: " + z.msg);
+                if (err != JZlib.Z_OK && err != JZlib.Z_STREAM_END)
                     throw new IOException((compress ? "de" : "in") + "flating: " + z.msg);
 
                 output.Write(buf, 0, buf.Length - z.avail_out);
             }
-            while (z.avail_in > 0 || z.avail_out == 0);
+            while ((z.avail_in > 0 || z.avail_out == 0) && err == JZlib.Z_OK);
         }
 
         public override void WriteByte(byte value)

--- a/crypto/src/util/zlib/ZStream.cs
+++ b/crypto/src/util/zlib/ZStream.cs
@@ -160,13 +160,21 @@ namespace Org.BouncyCastle.Utilities.Zlib {
             if(len>avail_out) len=avail_out;
             if(len==0) return;
 
-            if(dstate.pending_buf.Length<=dstate.pending_out ||
-                next_out.Length<=next_out_index ||
-                dstate.pending_buf.Length<(dstate.pending_out+len) ||
-                next_out.Length<(next_out_index+len)){
-                //      System.out.println(dstate.pending_buf.length+", "+dstate.pending_out+
-                //			 ", "+next_out.length+", "+next_out_index+", "+len);
-                //      System.out.println("avail_out="+avail_out);
+            if (this.dstate.pending_buf.Length <= this.dstate.pending_out || this.next_out.Length <= this.next_out_index || this.dstate.pending_buf.Length < this.dstate.pending_out + len || this.next_out.Length < this.next_out_index + len)
+            {
+                Console.Out.WriteLine(string.Concat(new object[]
+                {
+                    this.dstate.pending_buf.Length,
+                    ", ",
+                    this.dstate.pending_out,
+                    ", ",
+                    this.next_out.Length,
+                    ", ",
+                    this.next_out_index,
+                    ", ",
+                    len
+                }));
+                Console.Out.WriteLine("avail_out=" + this.avail_out);
             }
 
             System.Array.Copy(dstate.pending_buf, dstate.pending_out,


### PR DESCRIPTION
The current zlib implementation is "mostly" fine, but some edge cases are not simulated properly.

This commit effectively puts it to parity with the C++ version, and allows this implementation to be used to open and compress "EdgeZlib" files used by various PS3 games.

## How has this been tested?

Compression/decompression of EdgeZlib files, Quazal packets and deflate http data.

Check this repo (where I used this change to remove a whoping 3 Zlib duplicata libraries (because none was right...)): https://github.com/GitHubProUser67/MultiServer3/tree/Super-Branch/BackendServices/CastleLibrary

## Checklist before requesting a review

- [ x] I have performed a self-review of my code
- [ x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update
