### PR TITLE
Fix GostR3410x2001 keys format

### DIFF
--- a/crypto/src/openssl/MiscPemGenerator.cs
+++ b/crypto/src/openssl/MiscPemGenerator.cs
@@ -287,8 +287,7 @@ namespace Org.BouncyCastle.OpenSsl
 
                 return info.ParsePrivateKey().GetEncoded();
             }
-            else if (algOid.Equals(X9ObjectIdentifiers.IdECPublicKey) ||
-                     algOid.Equals(CryptoProObjectIdentifiers.GostR3410x2001))
+            else if (algOid.Equals(X9ObjectIdentifiers.IdECPublicKey))
             {
                 keyType = "EC PRIVATE KEY";
 

--- a/crypto/src/security/PrivateKeyFactory.cs
+++ b/crypto/src/security/PrivateKeyFactory.cs
@@ -164,6 +164,7 @@ namespace Org.BouncyCastle.Security
                 }
 
                 return new ECPrivateKeyParameters(
+                    "ECGOST3410",
                     d,
                     new ECGost3410Parameters(
                         ecSpec,

--- a/crypto/src/x509/SubjectPublicKeyInfoFactory.cs
+++ b/crypto/src/x509/SubjectPublicKeyInfoFactory.cs
@@ -1,5 +1,5 @@
 using System;
-
+using System.Collections.Generic;
 using Org.BouncyCastle.Asn1;
 using Org.BouncyCastle.Asn1.CryptoPro;
 using Org.BouncyCastle.Asn1.EdEC;
@@ -21,6 +21,15 @@ namespace Org.BouncyCastle.X509
     /// </summary>
     public static class SubjectPublicKeyInfoFactory
     {
+        private static readonly HashSet<DerObjectIdentifier> cryptoProOids = new HashSet<DerObjectIdentifier>
+        {
+            CryptoProObjectIdentifiers.GostR3410x2001CryptoProA,
+            CryptoProObjectIdentifiers.GostR3410x2001CryptoProB,
+            CryptoProObjectIdentifiers.GostR3410x2001CryptoProC,
+            CryptoProObjectIdentifiers.GostR3410x2001CryptoProXchA,
+            CryptoProObjectIdentifiers.GostR3410x2001CryptoProXchB,
+        };
+
         /// <summary>
         /// Create a Subject Public Key Info object for a given public key.
         /// </summary>
@@ -71,9 +80,19 @@ namespace Org.BouncyCastle.X509
                 if (ecKey.Parameters is ECGost3410Parameters gostParams)
                 {
                     int fieldSize = ecKey.Parameters.Curve.FieldElementEncodingLength;
-                    var algOid = fieldSize > 32
-                        ? RosstandartObjectIdentifiers.id_tc26_gost_3410_12_512
-                        : RosstandartObjectIdentifiers.id_tc26_gost_3410_12_256;
+                    DerObjectIdentifier algOid;
+
+                    if (cryptoProOids.Contains(gostParams.PublicKeyParamSet))
+                    {
+                        algOid = CryptoProObjectIdentifiers.GostR3410x2001;
+                    }
+                    else
+                    {
+                        algOid = fieldSize > 32
+                            ? RosstandartObjectIdentifiers.id_tc26_gost_3410_12_512
+                            : RosstandartObjectIdentifiers.id_tc26_gost_3410_12_256;
+                    }
+
                     var algParams = new Gost3410PublicKeyAlgParameters(gostParams.PublicKeyParamSet,
                         gostParams.DigestParamSet, gostParams.EncryptionParamSet);
                     var algID = new AlgorithmIdentifier(algOid, algParams);


### PR DESCRIPTION
## Describe your changes
Fixed some things for GostR3410x2001:
- Fixed PrivateKeyInfoFactory and SubjectPublicKeyInfoFactory like in a java-version of library.
- Fixed PEM generation of private key, now it's compatible with openssl and has the correct algorithm oid inside.
- Fixed PublicKeyFactory.CreateKey method so it fills the AlgorithmName field correctly.

## How has this been tested?

```csharp
    public void TestGost2001()
    {
        // Create keyPair
        var oid = CryptoProObjectIdentifiers.GostR3410x2001CryptoProB;
        var ecp = new ECNamedDomainParameters(oid, ECGost3410NamedCurves.GetByOid(oid));
        var gostParams = new ECGost3410Parameters(ecp, oid, CryptoProObjectIdentifiers.GostR3411x94CryptoProParamSet, null);
        var parameters = new ECKeyGenerationParameters(gostParams, new SecureRandom());
        var engine = new ECKeyPairGenerator("ECGOST3410");
        engine.Init(parameters);
        var keyPair = engine.GenerateKeyPair();

        // Convert PrivateKey to PEM
        using var writer = new StringWriter();
        using var pemWriter = new PemWriter(writer);
        pemWriter.WriteObject(keyPair.Private);
        pemWriter.Writer.Flush();
        var privateKeyPem = writer.ToString();
        Console.WriteLine(privateKeyPem);
        // We can compare pem format with any private key generated by openssl in any asn.1 decoder:
        // openssl genpkey -out private_gost2001.pem -engine gost -algorithm gost2001 -pkeyopt paramset:B
        // We can read pem data using openssl and run check if it works:
        // openssl pkey -engine gost -in test.key -text

        // Encode to DER
        var privateKeyDer = PrivateKeyInfoFactory.CreatePrivateKeyInfo(keyPair.Private).GetDerEncoded();
        var publicKeyDer = SubjectPublicKeyInfoFactory.CreateSubjectPublicKeyInfo(keyPair.Public).GetDerEncoded();

        // Decode from DER
        var privateKeyInfo = PrivateKeyInfo.GetInstance(privateKeyDer);
        var privateKey = (ECPrivateKeyParameters)PrivateKeyFactory.CreateKey(privateKeyInfo);
        var publicKeyInfo = SubjectPublicKeyInfo.GetInstance(publicKeyDer);
        var publicKey = (ECPublicKeyParameters)PublicKeyFactory.CreateKey(publicKeyInfo);

        // Both keys must have AlgorithmName is equal to ECGOST3410
        Assert.That(privateKey.AlgorithmName, Is.EqualTo("ECGOST3410"));
        Assert.That(publicKey.AlgorithmName, Is.EqualTo("ECGOST3410"));

        // D's match
        Assert.That(privateKey.D, Is.EqualTo(((ECPrivateKeyParameters)keyPair.Private).D));
        // Q's match
        Assert.That(publicKey.Q, Is.EqualTo(((ECPublicKeyParameters)keyPair.Public).Q));

        // Algorithm.Id must be GostR3410x2001
        Assert.That(privateKeyInfo.PrivateKeyAlgorithm.Algorithm, Is.EqualTo(CryptoProObjectIdentifiers.GostR3410x2001));

        // Testing PEM decoding
        using var textReader = new StringReader(privateKeyPem);
        using var pemReader = new PemReader(textReader);
        var pemObj = pemReader.ReadObject();
        Assert.That(pemObj, Is.TypeOf<ECPrivateKeyParameters>());
        var privateKeyFromPem = (ECPrivateKeyParameters)pemObj;

        Assert.That(privateKeyFromPem.AlgorithmName, Is.EqualTo("ECGOST3410"));
        Assert.That(privateKeyFromPem.D, Is.EqualTo(((ECPrivateKeyParameters)keyPair.Private).D));
    }
```

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
