### PR TITLE
Fix hash size in HashMLDsaSigner.FinishPreHash (in span branch).

### DIFF
--- a/crypto/src/crypto/signers/HashMLDsaSigner.cs
+++ b/crypto/src/crypto/signers/HashMLDsaSigner.cs
@@ -119,7 +119,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             ShakeDigest msgRepDigest = new ShakeDigest(m_msgRepDigest);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
-            Span<byte> preHash = stackalloc byte[msgRepDigest.GetDigestSize()];
+            Span<byte> preHash = stackalloc byte[m_preHashDigest.GetDigestSize()];
             m_preHashDigest.DoFinal(preHash);
             msgRepDigest.BlockUpdate(preHash);
 #else


### PR DESCRIPTION
## Describe your changes

Fix buffer creation for prehash in `HashMLDsaSigner.FinishPreHash` method. Previously, the size from the incorrect digest algorithm instance was used to create the buffer.

## How has this been tested?

I ran unit tests for MLDsa.

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
