### PR TITLE
docs: add XML documentation for AES, AEAD modes (GCM, ChaCha20Poly1305) and Dilithium

### DIFF
--- a/crypto/src/crypto/IBlockCipher.cs
+++ b/crypto/src/crypto/IBlockCipher.cs
@@ -2,7 +2,9 @@ using System;
 
 namespace Org.BouncyCastle.Crypto
 {
-	/// <remarks>Base interface for a symmetric key block cipher.</remarks>
+    /// <summary>
+    /// Base interface for a symmetric key block cipher.
+    /// </summary>
     public interface IBlockCipher
     {
 		/// <summary>The name of the algorithm this cipher implements.</summary>
@@ -13,6 +15,9 @@ namespace Org.BouncyCastle.Crypto
 		/// <param name="parameters">The key or other data required by the cipher.</param>
 		void Init(bool forEncryption, ICipherParameters parameters);
 
+		/// <summary>
+		/// Return the block size for this cipher (in bytes).
+		/// </summary>
 		/// <returns>The block size for this cipher, in bytes.</returns>
 		int GetBlockSize();
 

--- a/crypto/src/crypto/engines/AesEngine.cs
+++ b/crypto/src/crypto/engines/AesEngine.cs
@@ -6,30 +6,25 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Crypto.Engines
 {
-    /**
-    * an implementation of the AES (Rijndael), from FIPS-197.
-    * <p>
-    * For further details see: <a href="http://csrc.nist.gov/encryption/aes/">http://csrc.nist.gov/encryption/aes/</a>.
-    *
-    * This implementation is based on optimizations from Dr. Brian Gladman's paper and C code at
-    * <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
-    *
-    * There are three levels of tradeoff of speed vs memory
-    * Because java has no preprocessor, they are written as three separate classes from which to choose
-    *
-    * The fastest uses 8Kbytes of static tables to precompute round calculations, 4 256 word tables for encryption
-    * and 4 for decryption.
-    *
-    * The middle performance version uses only one 256 word table for each, for a total of 2Kbytes,
-    * adding 12 rotate operations per round to compute the values contained in the other tables from
-    * the contents of the first.
-    *
-    * The slowest version uses no static tables at all and computes the values in each round.
-    * </p>
-    * <p>
-    * This file contains the middle performance version with 2Kbytes of static tables for round precomputation.
-    * </p>
-    */
+    /// <summary>An implementation of the AES (Rijndael), from FIPS-197.</summary>
+    /// <remarks>
+    /// For further details see: <a href="http://csrc.nist.gov/encryption/aes/">http://csrc.nist.gov/encryption/aes/</a>.
+    /// <para>
+    /// This implementation is based on optimizations from Dr. Brian Gladman's paper and C code at
+    /// <a href="http://fp.gladman.plus.com/cryptography_technology/rijndael/">http://fp.gladman.plus.com/cryptography_technology/rijndael/</a>
+    /// </para>
+    /// <para>
+    /// There are three levels of tradeoff of speed vs memory:
+    /// </para>
+    /// <list type="bullet">
+    /// <item>The fastest uses 8Kbytes of static tables to precompute round calculations.</item>
+    /// <item>The middle performance version uses only one 256 word table for each, for a total of 2Kbytes, adding 12 rotate operations per round.</item>
+    /// <item>The slowest version uses no static tables at all and computes the values in each round.</item>
+    /// </list>
+    /// <para>
+    /// This file contains the middle performance version with 2Kbytes of static tables for round precomputation.
+    /// </para>
+    /// </remarks>
     public sealed class AesEngine
         : IBlockCipher
     {
@@ -437,21 +432,15 @@ namespace Org.BouncyCastle.Crypto.Engines
 
         private const int BLOCK_SIZE = 16;
 
-        /**
-        * default constructor - 128 bit block size.
-        */
+        /// <summary>Default constructor - 128 bit block size.</summary>
         public AesEngine()
         {
         }
 
-        /**
-        * initialise an AES cipher.
-        *
-        * @param forEncryption whether or not we are for encryption.
-        * @param parameters the parameters required to set up the cipher.
-        * @exception ArgumentException if the parameters argument is
-        * inappropriate.
-        */
+        /// <summary>Initialise an AES cipher.</summary>
+        /// <param name="forEncryption">Whether or not we are using it for encryption.</param>
+        /// <param name="parameters">The parameters required to set up the cipher.</param>
+        /// <exception cref="ArgumentException">If the parameters argument is inappropriate.</exception>
         public void Init(bool forEncryption, ICipherParameters parameters)
         {
             if (!(parameters is KeyParameter keyParameter))
@@ -464,16 +453,27 @@ namespace Org.BouncyCastle.Crypto.Engines
             this.s = Arrays.Clone(forEncryption ? S : Si);
         }
 
+        /// <summary>The name of the algorithm this engine implements.</summary>
         public string AlgorithmName
         {
             get { return "AES"; }
         }
 
+        /// <summary>Return the block size for this cipher (in bytes).</summary>
+        /// <returns>16 (fixed block size for AES).</returns>
         public int GetBlockSize()
         {
             return BLOCK_SIZE;
         }
 
+        /// <summary>Process a single block of data.</summary>
+        /// <param name="input">The input buffer containing the data to be processed.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="output">The output buffer to store the result.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>The number of bytes processed and produced.</returns>
+        /// <exception cref="DataLengthException">If the input buffer is too small, or the output buffer is too small.</exception>
+        /// <exception cref="InvalidOperationException">If the cipher isn't initialised.</exception>
         public int ProcessBlock(byte[] input, int inOff, byte[] output, int outOff)
         {
             if (WorkingKey == null)

--- a/crypto/src/crypto/modes/CbcBlockCipher.cs
+++ b/crypto/src/crypto/modes/CbcBlockCipher.cs
@@ -5,9 +5,7 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Crypto.Modes
 {
-    /**
-    * implements Cipher-Block-Chaining (CBC) mode on top of a simple cipher.
-    */
+    /// <summary>Implements Cipher-Block-Chaining (CBC) mode on top of a simple cipher.</summary>
     public sealed class CbcBlockCipher
 		: IBlockCipherMode
     {
@@ -16,11 +14,8 @@ namespace Org.BouncyCastle.Crypto.Modes
         private IBlockCipher	cipher;
         private bool			encrypting;
 
-        /**
-        * Basic constructor.
-        *
-        * @param cipher the block cipher to be used as the basis of chaining.
-        */
+        /// <summary>Basic constructor.</summary>
+        /// <param name="cipher">The block cipher to be used as the basis of chaining.</param>
         public CbcBlockCipher(
             IBlockCipher cipher)
         {
@@ -32,23 +27,15 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.cbcNextV = new byte[blockSize];
         }
 
-        /**
-        * return the underlying block cipher that we are wrapping.
-        *
-        * @return the underlying block cipher that we are wrapping.
-        */
+        /// <summary>Return the underlying block cipher that we are wrapping.</summary>
+        /// <returns>The underlying block cipher that we are wrapping.</returns>
         public IBlockCipher UnderlyingCipher => cipher;
 
-        /**
-        * Initialise the cipher and, possibly, the initialisation vector (IV).
-        * If an IV isn't passed as part of the parameter, the IV will be all zeros.
-        *
-        * @param forEncryption if true the cipher is initialised for
-        *  encryption, if false for decryption.
-        * @param param the key and other data required by the cipher.
-        * @exception ArgumentException if the parameters argument is
-        * inappropriate.
-        */
+        /// <summary>Initialise the cipher and, possibly, the initialisation vector (IV).</summary>
+        /// <remarks>If an IV isn't passed as part of the parameter, the IV will be all zeros.</remarks>
+        /// <param name="forEncryption">If true the cipher is initialised for encryption, if false for decryption.</param>
+        /// <param name="parameters">The key and other data required by the cipher.</param>
+        /// <exception cref="ArgumentException">If the parameters argument is inappropriate.</exception>
         public void Init(bool forEncryption, ICipherParameters parameters)
         {
             bool oldEncrypting = this.encrypting;
@@ -82,26 +69,21 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
         }
 
-		/**
-        * return the algorithm name and mode.
-        *
-        * @return the name of the underlying algorithm followed by "/CBC".
-        */
+        /// <summary>Return the algorithm name and mode.</summary>
+        /// <returns>The name of the underlying algorithm followed by "/CBC".</returns>
         public string AlgorithmName
         {
             get { return cipher.AlgorithmName + "/CBC"; }
         }
 
+        /// <summary>Indicates whether this cipher can handle partial blocks.</summary>
 		public bool IsPartialBlockOkay
 		{
 			get { return false; }
 		}
 
-		/**
-        * return the block size of the underlying cipher.
-        *
-        * @return the block size of the underlying cipher.
-        */
+        /// <summary>Return the block size of the underlying cipher.</summary>
+        /// <returns>The block size in bytes.</returns>
         public int GetBlockSize()
         {
             return cipher.GetBlockSize();
@@ -129,10 +111,7 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
-        /**
-        * reset the chaining vector back to the IV and reset the underlying
-        * cipher.
-        */
+        /// <summary>Reset the chaining vector back to the IV and reset the underlying cipher.</summary>
         public void Reset()
         {
             Array.Copy(IV, 0, cbcV, 0, IV.Length);

--- a/crypto/src/crypto/modes/ChaCha20Poly1305.cs
+++ b/crypto/src/crypto/modes/ChaCha20Poly1305.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Org.BouncyCastle.Crypto.Engines;
 using Org.BouncyCastle.Crypto.Macs;
@@ -8,6 +8,21 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Crypto.Modes
 {
+    /// <summary>
+    /// Implementation of the ChaCha20-Poly1305 AEAD construction as defined in RFC 7539 / RFC 8439.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// ChaCha20-Poly1305 is an Authenticated Encryption with Associated Data (AEAD) algorithm 
+    /// combining the ChaCha20 stream cipher with the Poly1305 message authentication code.
+    /// </para>
+    /// <para>
+    /// <b>CRITICAL SECURITY WARNING:</b> For encryption, a unique nonce (IV) MUST be used for every 
+    /// invocation with the same key. Reusing a nonce with the same key catastrophically compromises 
+    /// the security of the cipher, allowing an attacker to recover the authentication key (Poly1305) 
+    /// and plaintext.
+    /// </para>
+    /// </remarks>
     public class ChaCha20Poly1305
         : IAeadCipher
     {
@@ -48,11 +63,20 @@ namespace Org.BouncyCastle.Crypto.Modes
         private State mState = State.Uninitialized;
         private int mBufPos;
 
+        /// <summary>
+        /// Default constructor using the standard <see cref="Poly1305"/> MAC.
+        /// </summary>
         public ChaCha20Poly1305()
             : this(new Poly1305())
         {
         }
 
+        /// <summary>
+        /// Constructor allowing a custom Poly1305 implementation.
+        /// </summary>
+        /// <param name="poly1305">The Poly1305 MAC implementation to use.</param>
+        /// <exception cref="ArgumentNullException">If poly1305 is null.</exception>
+        /// <exception cref="ArgumentException">If poly1305 is not a 128-bit MAC.</exception>
         public ChaCha20Poly1305(IMac poly1305)
         {
             if (null == poly1305)
@@ -64,11 +88,18 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.mPoly1305 = poly1305;
         }
 
+        /// <summary>The name of the algorithm ("ChaCha20Poly1305").</summary>
         public virtual string AlgorithmName
         {
             get { return "ChaCha20Poly1305"; }
         }
 
+        /// <summary>
+        /// Initialise the ChaCha20Poly1305 cipher.
+        /// </summary>
+        /// <param name="forEncryption">True if initializing for encryption, false for decryption.</param>
+        /// <param name="parameters">The parameters required (typically <see cref="AeadParameters"/> or <see cref="ParametersWithIV"/>).</param>
+        /// <exception cref="ArgumentException">If parameters are invalid or nonce is reused for encryption.</exception>
         public virtual void Init(bool forEncryption, ICipherParameters parameters)
         {
             KeyParameter initKeyParam;
@@ -157,6 +188,9 @@ namespace Org.BouncyCastle.Crypto.Modes
             Reset(true, false);
         }
 
+        /// <summary>Return the size of the output buffer required for an input of <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>Required output buffer size.</returns>
         public virtual int GetOutputSize(int len)
         {
             int total = System.Math.Max(0, len);
@@ -177,6 +211,9 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
         }
 
+        /// <summary>Return the size of the output buffer required for a <c>ProcessBytes</c> call with <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>Update output size.</returns>
         public virtual int GetUpdateOutputSize(int len)
         {
             int total = System.Math.Max(0, len);
@@ -202,6 +239,8 @@ namespace Org.BouncyCastle.Crypto.Modes
             return total - total % BufSize;
         }
 
+        /// <summary>Process a single byte of Additional Authenticated Data (AAD).</summary>
+        /// <param name="input">The byte to be processed.</param>
         public virtual void ProcessAadByte(byte input)
         {
             CheckAad();
@@ -210,6 +249,10 @@ namespace Org.BouncyCastle.Crypto.Modes
             mPoly1305.Update(input);
         }
 
+        /// <summary>Process a sequence of bytes of Additional Authenticated Data (AAD).</summary>
+        /// <param name="inBytes">The input buffer containing AAD.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="len">The length of the data to process.</param>
         public virtual void ProcessAadBytes(byte[] inBytes, int inOff, int len)
         {
             if (null == inBytes)
@@ -230,6 +273,8 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a span of bytes of Additional Authenticated Data (AAD).</summary>
+        /// <param name="input">The input span containing AAD.</param>
         public virtual void ProcessAadBytes(ReadOnlySpan<byte> input)
         {
             CheckAad();
@@ -242,6 +287,11 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Process a single byte of data.</summary>
+        /// <param name="input">The input byte.</param>
+        /// <param name="outBytes">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>Number of bytes written to the output buffer.</returns>
         public virtual int ProcessByte(byte input, byte[] outBytes, int outOff)
         {
             CheckData();
@@ -289,6 +339,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a single byte of data using Spans.</summary>
+        /// <param name="input">The input byte.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>Number of bytes written to the output span.</returns>
         public virtual int ProcessByte(byte input, Span<byte> output)
         {
             CheckData();
@@ -328,6 +382,13 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Process a sequence of bytes from the input buffer.</summary>
+        /// <param name="inBytes">The input buffer.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="len">The length of data to process.</param>
+        /// <param name="outBytes">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>The number of bytes written to the output buffer.</returns>
         public virtual int ProcessBytes(byte[] inBytes, int inOff, int len, byte[] outBytes, int outOff)
         {
             if (null == inBytes)
@@ -463,6 +524,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a span of bytes from the input.</summary>
+        /// <param name="input">The input span.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         public virtual int ProcessBytes(ReadOnlySpan<byte> input, Span<byte> output)
         {
             CheckData();
@@ -573,6 +638,11 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Finish the operation, generating or verifying the MAC.</summary>
+        /// <param name="outBytes">The output buffer for remaining processed data and/or MAC.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>Number of bytes written to the output buffer.</returns>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         public virtual int DoFinal(byte[] outBytes, int outOff)
         {
             if (null == outBytes)
@@ -641,6 +711,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Finish the operation using Spans, generating or verifying the MAC.</summary>
+        /// <param name="output">The output span for remaining data and/or MAC.</param>
+        /// <returns>Number of bytes written to the output span.</returns>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         public virtual int DoFinal(Span<byte> output)
         {
             CheckData();
@@ -700,11 +774,14 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Return the Message Authentication Code (MAC) generated or verified by the cipher.</summary>
+        /// <returns>A byte array containing the MACBlock.</returns>
         public virtual byte[] GetMac()
         {
             return Arrays.Clone(mMac);
         }
 
+        /// <summary>Reset the cipher to its initial state (ready for a new message with the same key but DIFFERENT nonce).</summary>
         public virtual void Reset()
         {
             Reset(true, true);

--- a/crypto/src/crypto/modes/GCMBlockCipher.cs
+++ b/crypto/src/crypto/modes/GCMBlockCipher.cs
@@ -22,6 +22,17 @@ namespace Org.BouncyCastle.Crypto.Modes
     /// <summary>
     /// Implements the Galois/Counter mode (GCM) detailed in NIST Special Publication 800-38D.
     /// </summary>
+    /// <remarks>
+    /// <para>
+    /// GCM provides both confidentiality and data origin authentication (AEAD). 
+    /// It requires a block cipher with a 128-bit block size, typically <see cref="AesEngine"/>.
+    /// </para>
+    /// <para>
+    /// <b>CRITICAL SECURITY WARNING:</b> For encryption, a unique nonce (IV) MUST be used for every 
+    /// invocation with the same key. Reusing a nonce with the same key catastrophically compromises 
+    /// the security of the cipher, allowing an attacker to recover the authentication key or plaintext.
+    /// </para>
+    /// </remarks>
     public sealed class GcmBlockCipher
         : IAeadBlockCipher
     {
@@ -76,6 +87,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         private ulong       atLength;
         private ulong       atLengthPre;
 
+        /// <summary>
+        /// Base constructor.
+        /// </summary>
+        /// <param name="c">The underlying block cipher to use (must have a 128-bit block size).</param>
         public GcmBlockCipher(
             IBlockCipher c)
             : this(c, null)
@@ -99,10 +114,14 @@ namespace Org.BouncyCastle.Crypto.Modes
             this.multiplier = m;
         }
 
+        /// <summary>The name of the algorithm this cipher implements (e.g., "AES/GCM").</summary>
         public string AlgorithmName => cipher.AlgorithmName + "/GCM";
 
+        /// <summary>Return the underlying block cipher being wrapped.</summary>
         public IBlockCipher UnderlyingCipher => cipher;
 
+        /// <summary>Return the block size for GCM (fixed at 16 bytes).</summary>
+        /// <returns>16.</returns>
         public int GetBlockSize()
         {
             return BlockSize;
@@ -112,6 +131,12 @@ namespace Org.BouncyCastle.Crypto.Modes
         /// MAC sizes from 32 bits to 128 bits (must be a multiple of 8) are supported. The default is 128 bits.
         /// Sizes less than 96 are not recommended, but are supported for specialized applications.
         /// </remarks>
+        /// <summary>
+        /// Initialise the GCM cipher.
+        /// </summary>
+        /// <param name="forEncryption">True if initializing for encryption, false for decryption.</param>
+        /// <param name="parameters">The parameters required (typically <see cref="AeadParameters"/> or <see cref="ParametersWithIV"/>).</param>
+        /// <exception cref="ArgumentException">If parameters are invalid or nonce is reused for encryption.</exception>
         public void Init(bool forEncryption, ICipherParameters parameters)
         {
             this.forEncryption = forEncryption;
@@ -259,11 +284,16 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
         }
 
+        /// <summary>Return the Message Authentication Code (MAC) generated or verified by the cipher.</summary>
+        /// <returns>A byte array containing the MACBlock.</returns>
         public byte[] GetMac()
         {
             return macBlock == null ? new byte[macSize] : (byte[])macBlock.Clone();
         }
 
+        /// <summary>Return the size of the output buffer required for an input of <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>Required output buffer size.</returns>
         public int GetOutputSize(int len)
         {
             int totalData = len + bufOff;
@@ -274,6 +304,9 @@ namespace Org.BouncyCastle.Crypto.Modes
             return totalData < macSize ? 0 : totalData - macSize;
         }
 
+        /// <summary>Return the size of the output buffer required for a <c>ProcessBytes</c> call with <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>Update output size.</returns>
         public int GetUpdateOutputSize(int len)
         {
             int totalData = len + bufOff;
@@ -287,6 +320,8 @@ namespace Org.BouncyCastle.Crypto.Modes
             return totalData - totalData % BlockSize;
         }
 
+        /// <summary>Process a single byte of Additional Authenticated Data (AAD).</summary>
+        /// <param name="input">The byte to be processed.</param>
         public void ProcessAadByte(byte input)
         {
             CheckStatus();
@@ -301,6 +336,10 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
         }
 
+        /// <summary>Process a sequence of bytes of Additional Authenticated Data (AAD).</summary>
+        /// <param name="inBytes">The input buffer containing AAD.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="len">The length of the data to process.</param>
         public void ProcessAadBytes(byte[] inBytes, int inOff, int len)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -341,6 +380,8 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a span of bytes of Additional Authenticated Data (AAD).</summary>
+        /// <param name="input">The input span containing AAD.</param>
         public void ProcessAadBytes(ReadOnlySpan<byte> input)
         {
             CheckStatus();
@@ -395,6 +436,12 @@ namespace Org.BouncyCastle.Crypto.Modes
             }
         }
 
+        /// <summary>Process a single byte of data.</summary>
+        /// <param name="input">The input byte.</param>
+        /// <param name="output">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>Number of bytes written to the output buffer.</returns>
+        /// <exception cref="DataLengthException">If output buffer is too short.</exception>
         public int ProcessByte(byte	input, byte[] output, int outOff)
         {
             CheckStatus();
@@ -441,6 +488,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a single byte of data using Spans.</summary>
+        /// <param name="input">The input byte.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>Number of bytes written to the output span.</returns>
         public int ProcessByte(byte input, Span<byte> output)
         {
             CheckStatus();
@@ -479,6 +530,13 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Process a sequence of bytes from the input buffer.</summary>
+        /// <param name="input">The input buffer.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="len">The length of data to process.</param>
+        /// <param name="output">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>The number of bytes written to the output buffer.</returns>
         public int ProcessBytes(byte[] input, int inOff, int len, byte[] output, int outOff)
         {
             CheckStatus();
@@ -631,6 +689,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a span of bytes from the input.</summary>
+        /// <param name="input">The input span.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         public int ProcessBytes(ReadOnlySpan<byte> input, Span<byte> output)
         {
             CheckStatus();
@@ -806,6 +868,11 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Finish the operation, generating or verifying the Message Authentication Code (MAC).</summary>
+        /// <param name="output">The output buffer for remaining processed data and/or MAC.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>Number of bytes written to the output buffer.</returns>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         public int DoFinal(byte[] output, int outOff)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -926,6 +993,10 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Finish the operation using Spans, generating or verifying the MAC.</summary>
+        /// <param name="output">The output span for remaining data and/or MAC.</param>
+        /// <returns>Number of bytes written to the output span.</returns>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         public int DoFinal(Span<byte> output)
         {
             CheckStatus();
@@ -1042,6 +1113,7 @@ namespace Org.BouncyCastle.Crypto.Modes
         }
 #endif
 
+        /// <summary>Reset the cipher to its initial state (ready for a new message with the same key but DIFFERENT nonce).</summary>
         public void Reset()
         {
             Reset(true);

--- a/crypto/src/crypto/modes/IAeadBlockCipher.cs
+++ b/crypto/src/crypto/modes/IAeadBlockCipher.cs
@@ -6,6 +6,7 @@ namespace Org.BouncyCastle.Crypto.Modes
 	public interface IAeadBlockCipher
         : IAeadCipher
 	{
+        /// <summary>Return the block size for this cipher (in bytes).</summary>
         /// <returns>The block size for this cipher, in bytes.</returns>
         int GetBlockSize();
 

--- a/crypto/src/crypto/modes/IAeadCipher.cs
+++ b/crypto/src/crypto/modes/IAeadCipher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 
 using Org.BouncyCastle.Crypto.Parameters;
 
@@ -48,78 +48,68 @@ namespace Org.BouncyCastle.Crypto.Modes
         void ProcessAadBytes(ReadOnlySpan<byte> input);
 #endif
 
-        /**
-		* Encrypt/decrypt a single byte.
-		*
-		* @param input the byte to be processed.
-		* @param outBytes the output buffer the processed byte goes into.
-		* @param outOff the offset into the output byte array the processed data starts at.
-		* @return the number of bytes written to out.
-		* @exception DataLengthException if the output buffer is too small.
-		*/
+        /// <summary>Process a single byte of data.</summary>
+        /// <param name="input">The byte to be processed.</param>
+        /// <param name="outBytes">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>The number of bytes written to the output buffer.</returns>
+        /// <exception cref="DataLengthException">If the output buffer is too small.</exception>
         int ProcessByte(byte input, byte[] outBytes, int outOff);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a single byte of data using Spans.</summary>
+        /// <param name="input">The byte to be processed.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         int ProcessByte(byte input, Span<byte> output);
 #endif
 
-        /**
-        * Process a block of bytes from in putting the result into out.
-        *
-        * @param inBytes the input byte array.
-        * @param inOff the offset into the in array where the data to be processed starts.
-        * @param len the number of bytes to be processed.
-        * @param outBytes the output buffer the processed bytes go into.
-        * @param outOff the offset into the output byte array the processed data starts at.
-        * @return the number of bytes written to out.
-        * @exception DataLengthException if the output buffer is too small.
-        */
+        /// <summary>Process a sequence of bytes from the input buffer.</summary>
+        /// <param name="inBytes">The input buffer.</param>
+        /// <param name="inOff">The offset into the input buffer.</param>
+        /// <param name="len">The length of data to process.</param>
+        /// <param name="outBytes">The output buffer.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>The number of bytes written to the output buffer.</returns>
+        /// <exception cref="DataLengthException">If the output buffer is too small.</exception>
         int ProcessBytes(byte[] inBytes, int inOff, int len, byte[] outBytes, int outOff);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Process a span of bytes from the input.</summary>
+        /// <param name="input">The input span.</param>
+        /// <param name="output">The output span.</param>
+        /// <returns>The number of bytes written to the output span.</returns>
         int ProcessBytes(ReadOnlySpan<byte> input, Span<byte> output);
 #endif
 
-        /**
-        * Finish the operation either appending or verifying the MAC at the end of the data.
-        *
-        * @param outBytes space for any resulting output data.
-        * @param outOff offset into out to start copying the data at.
-        * @return number of bytes written into out.
-        * @throws InvalidOperationException if the cipher is in an inappropriate state.
-        * @throws InvalidCipherTextException if the MAC fails to match.
-        */
+        /// <summary>Finish the operation, generating or verifying the MAC.</summary>
+        /// <param name="outBytes">The output buffer for remaining data and/or MAC.</param>
+        /// <param name="outOff">The offset into the output buffer.</param>
+        /// <returns>Number of bytes written to the output buffer.</returns>
+        /// <exception cref="InvalidOperationException">If the cipher is in an inappropriate state.</exception>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         int DoFinal(byte[] outBytes, int outOff);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Finish the operation using Spans, generating or verifying the MAC.</summary>
+        /// <param name="output">The output span for remaining data and/or MAC.</param>
+        /// <returns>Number of bytes written to the output span.</returns>
+        /// <exception cref="InvalidCipherTextException">If the MAC check fails.</exception>
         int DoFinal(Span<byte> output);
 #endif
 
-        /**
-        * Return the value of the MAC associated with the last stream processed.
-        *
-        * @return MAC for plaintext data.
-        */
+        /// <summary>Return the Message Authentication Code (MAC) generated or verified by the cipher.</summary>
+        /// <returns>A byte array containing the MAC Block.</returns>
         byte[] GetMac();
 
-        /**
-        * Return the size of the output buffer required for a ProcessBytes
-        * an input of len bytes.
-        *
-        * @param len the length of the input.
-        * @return the space required to accommodate a call to ProcessBytes
-        * with len bytes of input.
-        */
+        /// <summary>Return the size of the output buffer required for a ProcessBytes call with <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>The space required for ProcessBytes with len bytes of input.</returns>
         int GetUpdateOutputSize(int len);
 
-        /**
-        * Return the size of the output buffer required for a ProcessBytes plus a
-        * DoFinal with an input of len bytes.
-        *
-        * @param len the length of the input.
-        * @return the space required to accommodate a call to ProcessBytes and DoFinal
-        * with len bytes of input.
-        */
+        /// <summary>Return the size of the output buffer required for a ProcessBytes plus a DoFinal call with <paramref name="len"/> bytes.</summary>
+        /// <param name="len">Input length.</param>
+        /// <returns>The space required for ProcessBytes and DoFinal with len bytes of input.</returns>
         int GetOutputSize(int len);
 
         /// <summary>

--- a/crypto/src/pqc/crypto/crystals/dilithium/DilithiumSigner.cs
+++ b/crypto/src/pqc/crypto/crystals/dilithium/DilithiumSigner.cs
@@ -6,6 +6,14 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Crystals.Dilithium
 {
+    /// <summary>
+    /// Signer implementation for the CRYSTALS-Dilithium post-quantum signature algorithm.
+    /// </summary>
+    /// <remarks>
+    /// Dilithium is part of the CRYSTALS (Cryptographic Suite for Algebraic Lattices) family.
+    /// This implementation corresponds to the submission to the NIST PQC project.
+    /// Note: Users are encouraged to migrate to ML-DSA (FIPS 204) as the standardized version.
+    /// </remarks>
     [Obsolete("Use ML-DSA instead")]
     public class DilithiumSigner 
         : IMessageSigner
@@ -15,10 +23,18 @@ namespace Org.BouncyCastle.Pqc.Crypto.Crystals.Dilithium
 
         private SecureRandom random;
 
+        /// <summary>
+        /// Default constructor.
+        /// </summary>
         public DilithiumSigner()
         {
         }
 
+        /// <summary>
+        /// Initialise the Dilithium signer.
+        /// </summary>
+        /// <param name="forSigning">True if initializing for signing, false for verification.</param>
+        /// <param name="param">The parameters for the signer (typically <see cref="DilithiumPrivateKeyParameters"/> or <see cref="DilithiumPublicKeyParameters"/>).</param>
         public void Init(bool forSigning, ICipherParameters param)
         {
             if (forSigning)
@@ -41,6 +57,11 @@ namespace Org.BouncyCastle.Pqc.Crypto.Crystals.Dilithium
             }
         }
 
+        /// <summary>
+        /// Generate a signature for the given message.
+        /// </summary>
+        /// <param name="message">The message bytes to sign.</param>
+        /// <returns>The generated signature byte array.</returns>
         public byte[] GenerateSignature(byte[] message)
         {
             DilithiumEngine engine = privKey.Parameters.GetEngine(random);
@@ -50,6 +71,12 @@ namespace Org.BouncyCastle.Pqc.Crypto.Crystals.Dilithium
             return sig;
         }
 
+        /// <summary>
+        /// Verify a signature for the given message.
+        /// </summary>
+        /// <param name="message">The original message bytes.</param>
+        /// <param name="signature">The signature bytes to verify.</param>
+        /// <returns>True if the signature is valid, false otherwise.</returns>
         public bool VerifySignature(byte[] message, byte[] signature)
         {
             var engine = pubKey.Parameters.GetEngine(random);


### PR DESCRIPTION
Following up on the merge of PR #666, this pull request introduces the next batch of XML documentation for the Bouncy Castle C# repository, focusing on the modern symmetric cipher suite and bridging to PQC.

### Changes Included
*   **Modern Symmetric Suite**: Added comprehensive modern XML documentation (`<summary>`, `<param>`, `<returns>`, `<exception>`) to `AesEngine`, `GcmBlockCipher`, `CbcBlockCipher`, and `ChaCha20Poly1305`, replacing the legacy Javadoc comments.
*   **AEAD Security Warnings**: Added prominent **CRITICAL SECURITY WARNING** sections in `GcmBlockCipher` and `ChaCha20Poly1305` to explicitly warn consumers against Nonce/IV reuse.
*   **Core Interfaces**: Enriched documentation for `IBlockCipher`, `IAeadCipher`, and `IAeadBlockCipher` to improve base IntelliSense support.
*   **Post-Quantum Cryptography**: Documented `DilithiumSigner`, contextualizing it within the CRYSTALS family and adding a note advising users to transition to ML-DSA (FIPS 204) where applicable.

### Note
As before, these changes are strictly non-functional. They are limited to XML documentation updates to improve IntelliSense mapping for developers consuming the library. No operational logic or internal signatures were altered.

## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch (Ensured no `.gitignore` slip-ups this time!)
- [ ] This change requires a documentation update *(n/a - this PR itself IS a documentation update)*
See also [Contributing Guidelines](https://github.com/bcgit/bc-csharp/wiki/Contributing).