### PR TITLE
docs: add XML documentation for modern-curve parameters (Batch 7)

### DIFF
--- a/crypto/src/crypto/parameters/Ed25519KeyGenerationParameters.cs
+++ b/crypto/src/crypto/parameters/Ed25519KeyGenerationParameters.cs
@@ -4,9 +4,16 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Key generation parameters for Ed25519 (RFC 8032). Carries the <see cref="SecureRandom"/> used for
+    /// seed generation; the strength is fixed at 256 bits.
+    /// </summary>
     public class Ed25519KeyGenerationParameters
         : KeyGenerationParameters
     {
+        /// <summary>
+        /// Construct using <paramref name="random"/> as the entropy source for the 32-byte seed.
+        /// </summary>
         public Ed25519KeyGenerationParameters(SecureRandom random)
             : base(random, 256)
         {

--- a/crypto/src/crypto/parameters/Ed25519PrivateKeyParameters.cs
+++ b/crypto/src/crypto/parameters/Ed25519PrivateKeyParameters.cs
@@ -8,27 +8,40 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Ed25519 private key (RFC 8032). Holds the 32-byte secret seed; the corresponding public key is
+    /// derived lazily on first use and cached.
+    /// </summary>
     public sealed class Ed25519PrivateKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an Ed25519 private-key seed (32).</summary>
         public static readonly int KeySize = Ed25519.SecretKeySize;
+
+        /// <summary>Length in bytes of an Ed25519 signature (64).</summary>
         public static readonly int SignatureSize = Ed25519.SignatureSize;
 
         private readonly byte[] data = new byte[KeySize];
 
         private Ed25519PublicKeyParameters cachedPublicKey;
 
+        /// <summary>Generate a fresh random Ed25519 private key using <paramref name="random"/>.</summary>
         public Ed25519PrivateKeyParameters(SecureRandom random)
             : base(true)
         {
             Ed25519.GeneratePrivateKey(random, data);
         }
 
+        /// <summary>Construct from a 32-byte seed buffer.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public Ed25519PrivateKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public Ed25519PrivateKeyParameters(byte[] buf, int off)
             : base(true)
         {
@@ -36,6 +49,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span carrying the 32-byte seed.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public Ed25519PrivateKeyParameters(ReadOnlySpan<byte> buf)
             : base(true)
         {
@@ -46,6 +62,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 32-byte seed from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public Ed25519PrivateKeyParameters(Stream input)
             : base(true)
         {
@@ -53,18 +72,21 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of Ed25519 private key");
         }
 
+        /// <summary>Write the 32-byte seed into <paramref name="buf"/> at <paramref name="off"/>.</summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 32-byte seed into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 32-byte seed.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);
@@ -76,9 +98,23 @@ namespace Org.BouncyCastle.Crypto.Parameters
         internal ReadOnlyMemory<byte> DataMemory => data;
 #endif
 
+        /// <summary>
+        /// Derive (and cache) the public key corresponding to this private key.
+        /// </summary>
         public Ed25519PublicKeyParameters GeneratePublicKey() =>
             Objects.EnsureSingletonInitialized(ref cachedPublicKey, data, CreatePublicKey);
 
+        /// <summary>
+        /// Compute an Ed25519 signature. Selects between pure Ed25519, Ed25519ctx and Ed25519ph based on
+        /// <paramref name="algorithm"/>. The pure variant rejects a non-<c>null</c> context; the context
+        /// and prehash variants require a context up to 255 bytes long, and Ed25519ph additionally
+        /// requires <paramref name="msgLen"/> to equal <see cref="Ed25519.PrehashSize"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="ctx"/> is required but
+        /// <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="ctx"/> exceeds 255 bytes,
+        /// is supplied for pure Ed25519, <paramref name="msgLen"/> is wrong for Ed25519ph, or
+        /// <paramref name="algorithm"/> is unrecognised.</exception>
         public void Sign(Ed25519.Algorithm algorithm, byte[] ctx, byte[] msg, int msgOff, int msgLen,
             byte[] sig, int sigOff)
         {
@@ -127,6 +163,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of
+        /// <see cref="Sign(Ed25519.Algorithm, byte[], byte[], int, int, byte[], int)"/>.
+        /// </summary>
         public void Sign(Ed25519.Algorithm algorithm, byte[] ctx, ReadOnlySpan<byte> msg, Span<byte> sig)
         {
             Ed25519PublicKeyParameters publicKey = GeneratePublicKey();

--- a/crypto/src/crypto/parameters/Ed25519PublicKeyParameters.cs
+++ b/crypto/src/crypto/parameters/Ed25519PublicKeyParameters.cs
@@ -6,18 +6,35 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Ed25519 public key (RFC 8032). Wraps a decoded curve point obtained from a 32-byte encoded
+    /// representation; the point is validated at construction so that subsequent verifications work
+    /// against a known-good key.
+    /// </summary>
     public sealed class Ed25519PublicKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an Ed25519 public key encoding (32).</summary>
         public static readonly int KeySize = Ed25519.PublicKeySize;
 
         private readonly Ed25519.PublicPoint m_publicPoint;
 
+        /// <summary>
+        /// Construct from a 32-byte buffer holding the encoded public point.
+        /// </summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>, or the encoding does not decode to a valid curve point.</exception>
         public Ed25519PublicKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>
+        /// Construct from <paramref name="buf"/> starting at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.
+        /// </summary>
+        /// <exception cref="ArgumentException">If the encoded bytes do not decode to a valid curve
+        /// point.</exception>
         public Ed25519PublicKeyParameters(byte[] buf, int off)
             : base(false)
         {
@@ -25,6 +42,11 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Construct from a span holding the encoded public point.
+        /// </summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>, or the encoding does not decode to a valid curve point.</exception>
         public Ed25519PublicKeyParameters(ReadOnlySpan<byte> buf)
             : base(false)
         {
@@ -35,6 +57,13 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>
+        /// Read <see cref="KeySize"/> encoded bytes from <paramref name="input"/> and decode them.
+        /// </summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
+        /// <exception cref="ArgumentException">If the encoded bytes do not decode to a valid curve
+        /// point.</exception>
         public Ed25519PublicKeyParameters(Stream input)
             : base(false)
         {
@@ -54,24 +83,33 @@ namespace Org.BouncyCastle.Crypto.Parameters
 #endif
         }
 
+        /// <summary>
+        /// Construct from an already-decoded curve point. No further validation is performed.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="publicPoint"/> is <c>null</c>.</exception>
         public Ed25519PublicKeyParameters(Ed25519.PublicPoint publicPoint)
             : base(false)
         {
             m_publicPoint = publicPoint ?? throw new ArgumentNullException(nameof(publicPoint));
         }
 
+        /// <summary>
+        /// Write the 32-byte encoded public point into <paramref name="buf"/> at <paramref name="off"/>.
+        /// </summary>
         public void Encode(byte[] buf, int off)
         {
             Ed25519.EncodePublicPoint(m_publicPoint, buf, off);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 32-byte encoded public point into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             Ed25519.EncodePublicPoint(m_publicPoint, buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 32-byte encoded public point.</summary>
         public byte[] GetEncoded()
         {
             byte[] data = new byte[KeySize];
@@ -79,6 +117,18 @@ namespace Org.BouncyCastle.Crypto.Parameters
             return data;
         }
 
+        /// <summary>
+        /// Verify an Ed25519 signature. Selects between pure Ed25519, Ed25519ctx and Ed25519ph based on
+        /// <paramref name="algorithm"/>. The pure variant rejects a non-<c>null</c> context; the context
+        /// and prehash variants require a context up to 255 bytes long, and Ed25519ph additionally
+        /// requires <paramref name="msgLen"/> to equal <see cref="Ed25519.PrehashSize"/>.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for this key; otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="ctx"/> is required but
+        /// <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="ctx"/> exceeds 255 bytes,
+        /// is supplied for pure Ed25519, <paramref name="msgLen"/> is wrong for Ed25519ph, or
+        /// <paramref name="algorithm"/> is unrecognised.</exception>
         public bool Verify(Ed25519.Algorithm algorithm, byte[] ctx, byte[] msg, int msgOff, int msgLen,
             byte[] sig, int sigOff)
         {
@@ -119,6 +169,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of
+        /// <see cref="Verify(Ed25519.Algorithm, byte[], byte[], int, int, byte[], int)"/>.
+        /// </summary>
         public bool Verify(Ed25519.Algorithm algorithm, byte[] ctx, ReadOnlySpan<byte> msg, ReadOnlySpan<byte> sig)
         {
             switch (algorithm)

--- a/crypto/src/crypto/parameters/Ed448KeyGenerationParameters.cs
+++ b/crypto/src/crypto/parameters/Ed448KeyGenerationParameters.cs
@@ -4,9 +4,16 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Key generation parameters for Ed448 (RFC 8032). Carries the <see cref="SecureRandom"/> used for
+    /// seed generation; the strength is fixed at 448 bits.
+    /// </summary>
     public class Ed448KeyGenerationParameters
         : KeyGenerationParameters
     {
+        /// <summary>
+        /// Construct using <paramref name="random"/> as the entropy source for the 57-byte seed.
+        /// </summary>
         public Ed448KeyGenerationParameters(SecureRandom random)
             : base(random, 448)
         {

--- a/crypto/src/crypto/parameters/Ed448PrivateKeyParameters.cs
+++ b/crypto/src/crypto/parameters/Ed448PrivateKeyParameters.cs
@@ -8,27 +8,40 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Ed448 private key (RFC 8032). Holds the 57-byte secret seed; the corresponding public key is
+    /// derived lazily on first use and cached.
+    /// </summary>
     public sealed class Ed448PrivateKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an Ed448 private-key seed (57).</summary>
         public static readonly int KeySize = Ed448.SecretKeySize;
+
+        /// <summary>Length in bytes of an Ed448 signature (114).</summary>
         public static readonly int SignatureSize = Ed448.SignatureSize;
 
         private readonly byte[] data = new byte[KeySize];
 
         private Ed448PublicKeyParameters cachedPublicKey;
 
+        /// <summary>Generate a fresh random Ed448 private key using <paramref name="random"/>.</summary>
         public Ed448PrivateKeyParameters(SecureRandom random)
             : base(true)
         {
             Ed448.GeneratePrivateKey(random, data);
         }
 
+        /// <summary>Construct from a 57-byte seed buffer.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public Ed448PrivateKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public Ed448PrivateKeyParameters(byte[] buf, int off)
             : base(true)
         {
@@ -36,6 +49,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span carrying the 57-byte seed.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public Ed448PrivateKeyParameters(ReadOnlySpan<byte> buf)
             : base(true)
         {
@@ -46,6 +62,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 57-byte seed from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public Ed448PrivateKeyParameters(Stream input)
             : base(true)
         {
@@ -53,18 +72,21 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of Ed448 private key");
         }
 
+        /// <summary>Write the 57-byte seed into <paramref name="buf"/> at <paramref name="off"/>.</summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 57-byte seed into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 57-byte seed.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);
@@ -76,9 +98,19 @@ namespace Org.BouncyCastle.Crypto.Parameters
         internal ReadOnlyMemory<byte> DataMemory => data;
 #endif
 
+        /// <summary>Derive (and cache) the public key corresponding to this private key.</summary>
         public Ed448PublicKeyParameters GeneratePublicKey() =>
             Objects.EnsureSingletonInitialized(ref cachedPublicKey, data, CreatePublicKey);
 
+        /// <summary>
+        /// Compute an Ed448 signature. Both Ed448 and Ed448ph require a non-<c>null</c> context up to
+        /// 255 bytes; Ed448ph additionally requires <paramref name="msgLen"/> to equal
+        /// <see cref="Ed448.PrehashSize"/>.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="ctx"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="ctx"/> exceeds 255 bytes,
+        /// <paramref name="msgLen"/> is wrong for Ed448ph, or <paramref name="algorithm"/> is
+        /// unrecognised.</exception>
         public void Sign(Ed448.Algorithm algorithm, byte[] ctx, byte[] msg, int msgOff, int msgLen,
             byte[] sig, int sigOff)
         {
@@ -119,6 +151,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of
+        /// <see cref="Sign(Ed448.Algorithm, byte[], byte[], int, int, byte[], int)"/>.
+        /// </summary>
         public void Sign(Ed448.Algorithm algorithm, byte[] ctx, ReadOnlySpan<byte> msg, Span<byte> sig)
         {
             Ed448PublicKeyParameters publicKey = GeneratePublicKey();

--- a/crypto/src/crypto/parameters/Ed448PublicKeyParameters.cs
+++ b/crypto/src/crypto/parameters/Ed448PublicKeyParameters.cs
@@ -6,18 +6,30 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Ed448 public key (RFC 8032). Wraps a decoded curve point obtained from a 57-byte encoded
+    /// representation; the point is validated at construction.
+    /// </summary>
     public sealed class Ed448PublicKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an Ed448 public key encoding (57).</summary>
         public static readonly int KeySize = Ed448.PublicKeySize;
 
         private readonly Ed448.PublicPoint m_publicPoint;
 
+        /// <summary>Construct from a 57-byte buffer holding the encoded public point.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>, or the encoding does not decode to a valid curve point.</exception>
         public Ed448PublicKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
+        /// <exception cref="ArgumentException">If the encoded bytes do not decode to a valid curve
+        /// point.</exception>
         public Ed448PublicKeyParameters(byte[] buf, int off)
             : base(false)
         {
@@ -25,6 +37,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span holding the encoded public point.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>, or the encoding does not decode to a valid curve point.</exception>
         public Ed448PublicKeyParameters(ReadOnlySpan<byte> buf)
             : base(false)
         {
@@ -35,6 +50,11 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read <see cref="KeySize"/> encoded bytes from <paramref name="input"/> and decode them.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
+        /// <exception cref="ArgumentException">If the encoded bytes do not decode to a valid curve
+        /// point.</exception>
         public Ed448PublicKeyParameters(Stream input)
             : base(false)
         {
@@ -54,24 +74,31 @@ namespace Org.BouncyCastle.Crypto.Parameters
 #endif
         }
 
+        /// <summary>Construct from an already-decoded curve point. No further validation is performed.</summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="publicPoint"/> is <c>null</c>.</exception>
         public Ed448PublicKeyParameters(Ed448.PublicPoint publicPoint)
             : base(false)
         {
             m_publicPoint = publicPoint ?? throw new ArgumentNullException(nameof(publicPoint));
         }
 
+        /// <summary>
+        /// Write the 57-byte encoded public point into <paramref name="buf"/> at <paramref name="off"/>.
+        /// </summary>
         public void Encode(byte[] buf, int off)
         {
             Ed448.EncodePublicPoint(m_publicPoint, buf, off);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 57-byte encoded public point into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             Ed448.EncodePublicPoint(m_publicPoint, buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 57-byte encoded public point.</summary>
         public byte[] GetEncoded()
         {
             byte[] data = new byte[KeySize];
@@ -79,6 +106,16 @@ namespace Org.BouncyCastle.Crypto.Parameters
             return data;
         }
 
+        /// <summary>
+        /// Verify an Ed448 signature. Both Ed448 and Ed448ph require a non-<c>null</c> context up to
+        /// 255 bytes; Ed448ph additionally requires <paramref name="msgLen"/> to equal
+        /// <see cref="Ed448.PrehashSize"/>.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for this key; otherwise <c>false</c>.</returns>
+        /// <exception cref="ArgumentNullException">If <paramref name="ctx"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentOutOfRangeException">If <paramref name="ctx"/> exceeds 255 bytes,
+        /// <paramref name="msgLen"/> is wrong for Ed448ph, or <paramref name="algorithm"/> is
+        /// unrecognised.</exception>
         public bool Verify(Ed448.Algorithm algorithm, byte[] ctx, byte[] msg, int msgOff, int msgLen,
             byte[] sig, int sigOff)
         {
@@ -112,6 +149,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of
+        /// <see cref="Verify(Ed448.Algorithm, byte[], byte[], int, int, byte[], int)"/>.
+        /// </summary>
         public bool Verify(Ed448.Algorithm algorithm, byte[] ctx, ReadOnlySpan<byte> msg, ReadOnlySpan<byte> sig)
         {
             switch (algorithm)

--- a/crypto/src/crypto/parameters/X25519KeyGenerationParameters.cs
+++ b/crypto/src/crypto/parameters/X25519KeyGenerationParameters.cs
@@ -4,9 +4,16 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Key generation parameters for X25519 (RFC 7748). Carries the <see cref="SecureRandom"/> used for
+    /// scalar generation; the strength is fixed at 255 bits.
+    /// </summary>
     public class X25519KeyGenerationParameters
         : KeyGenerationParameters
     {
+        /// <summary>
+        /// Construct using <paramref name="random"/> as the entropy source for the 32-byte scalar.
+        /// </summary>
         public X25519KeyGenerationParameters(SecureRandom random)
             : base(random, 255)
         {

--- a/crypto/src/crypto/parameters/X25519PrivateKeyParameters.cs
+++ b/crypto/src/crypto/parameters/X25519PrivateKeyParameters.cs
@@ -8,25 +8,38 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// X25519 private key (RFC 7748). Holds the 32-byte clamped scalar used in Curve25519
+    /// Diffie-Hellman.
+    /// </summary>
     public sealed class X25519PrivateKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an X25519 private-key scalar (32).</summary>
         public static readonly int KeySize = X25519.ScalarSize;
+
+        /// <summary>Length in bytes of the shared secret produced by an X25519 agreement (32).</summary>
         public static readonly int SecretSize = X25519.PointSize;
 
         private readonly byte[] data = new byte[KeySize];
 
+        /// <summary>Generate a fresh random X25519 private key using <paramref name="random"/>.</summary>
         public X25519PrivateKeyParameters(SecureRandom random)
             : base(true)
         {
             X25519.GeneratePrivateKey(random, data);
         }
 
+        /// <summary>Construct from a 32-byte scalar buffer.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X25519PrivateKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public X25519PrivateKeyParameters(byte[] buf, int off)
             : base(true)
         {
@@ -34,6 +47,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span carrying the 32-byte scalar.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X25519PrivateKeyParameters(ReadOnlySpan<byte> buf)
             : base(true)
         {
@@ -44,6 +60,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 32-byte scalar from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public X25519PrivateKeyParameters(Stream input)
             : base(true)
         {
@@ -51,18 +70,21 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of X25519 private key");
         }
 
+        /// <summary>Write the 32-byte scalar into <paramref name="buf"/> at <paramref name="off"/>.</summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 32-byte scalar into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 32-byte scalar.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);
@@ -74,6 +96,7 @@ namespace Org.BouncyCastle.Crypto.Parameters
         internal ReadOnlyMemory<byte> DataMemory => data;
 #endif
 
+        /// <summary>Compute the public key (u-coordinate) corresponding to this scalar.</summary>
         public X25519PublicKeyParameters GeneratePublicKey()
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -87,6 +110,13 @@ namespace Org.BouncyCastle.Crypto.Parameters
 #endif
         }
 
+        /// <summary>
+        /// Perform an X25519 Diffie-Hellman agreement against <paramref name="publicKey"/> and write the
+        /// resulting <see cref="SecretSize"/>-byte shared secret into <paramref name="buf"/> starting at
+        /// <paramref name="off"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret
+        /// (degenerate peer key).</exception>
         public void GenerateSecret(X25519PublicKeyParameters publicKey, byte[] buf, int off)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -100,6 +130,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of <see cref="GenerateSecret(X25519PublicKeyParameters, byte[], int)"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret.</exception>
         public void GenerateSecret(X25519PublicKeyParameters publicKey, Span<byte> buf)
         {
             Span<byte> encoded = stackalloc byte[X25519.PointSize];

--- a/crypto/src/crypto/parameters/X25519PublicKeyParameters.cs
+++ b/crypto/src/crypto/parameters/X25519PublicKeyParameters.cs
@@ -7,18 +7,29 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// X25519 public key (RFC 7748). Holds the 32-byte u-coordinate of the peer's curve point. The
+    /// encoding is stored verbatim; validation of the point is performed during scalar multiplication
+    /// in the agreement primitive.
+    /// </summary>
     public sealed class X25519PublicKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an X25519 public key encoding (32).</summary>
         public static readonly int KeySize = X25519.PointSize;
 
         private readonly byte[] data = new byte[KeySize];
 
+        /// <summary>Construct from a 32-byte buffer holding the encoded u-coordinate.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X25519PublicKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public X25519PublicKeyParameters(byte[] buf, int off)
             : base(false)
         {
@@ -26,6 +37,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span holding the encoded u-coordinate.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X25519PublicKeyParameters(ReadOnlySpan<byte> buf)
             : base(false)
         {
@@ -36,6 +50,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 32-byte encoded u-coordinate from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public X25519PublicKeyParameters(Stream input)
             : base(false)
         {
@@ -43,18 +60,23 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of X25519 public key");
         }
 
+        /// <summary>
+        /// Write the 32-byte encoded u-coordinate into <paramref name="buf"/> at <paramref name="off"/>.
+        /// </summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 32-byte encoded u-coordinate into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 32-byte encoded u-coordinate.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);

--- a/crypto/src/crypto/parameters/X448KeyGenerationParameters.cs
+++ b/crypto/src/crypto/parameters/X448KeyGenerationParameters.cs
@@ -4,9 +4,16 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// Key generation parameters for X448 (RFC 7748). Carries the <see cref="SecureRandom"/> used for
+    /// scalar generation; the strength is fixed at 448 bits.
+    /// </summary>
     public class X448KeyGenerationParameters
         : KeyGenerationParameters
     {
+        /// <summary>
+        /// Construct using <paramref name="random"/> as the entropy source for the 56-byte scalar.
+        /// </summary>
         public X448KeyGenerationParameters(SecureRandom random)
             : base(random, 448)
         {

--- a/crypto/src/crypto/parameters/X448PrivateKeyParameters.cs
+++ b/crypto/src/crypto/parameters/X448PrivateKeyParameters.cs
@@ -8,25 +8,38 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// X448 private key (RFC 7748). Holds the 56-byte clamped scalar used in Curve448
+    /// Diffie-Hellman.
+    /// </summary>
     public sealed class X448PrivateKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an X448 private-key scalar (56).</summary>
         public static readonly int KeySize = X448.ScalarSize;
+
+        /// <summary>Length in bytes of the shared secret produced by an X448 agreement (56).</summary>
         public static readonly int SecretSize = X448.PointSize;
 
         private readonly byte[] data = new byte[KeySize];
 
+        /// <summary>Generate a fresh random X448 private key using <paramref name="random"/>.</summary>
         public X448PrivateKeyParameters(SecureRandom random)
             : base(true)
         {
             X448.GeneratePrivateKey(random, data);
         }
 
+        /// <summary>Construct from a 56-byte scalar buffer.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X448PrivateKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public X448PrivateKeyParameters(byte[] buf, int off)
             : base(true)
         {
@@ -34,6 +47,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span carrying the 56-byte scalar.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X448PrivateKeyParameters(ReadOnlySpan<byte> buf)
             : base(true)
         {
@@ -44,6 +60,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 56-byte scalar from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public X448PrivateKeyParameters(Stream input)
             : base(true)
         {
@@ -51,18 +70,21 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of X448 private key");
         }
 
+        /// <summary>Write the 56-byte scalar into <paramref name="buf"/> at <paramref name="off"/>.</summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 56-byte scalar into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 56-byte scalar.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);
@@ -74,6 +96,7 @@ namespace Org.BouncyCastle.Crypto.Parameters
         internal ReadOnlyMemory<byte> DataMemory => data;
 #endif
 
+        /// <summary>Compute the public key (u-coordinate) corresponding to this scalar.</summary>
         public X448PublicKeyParameters GeneratePublicKey()
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -87,6 +110,13 @@ namespace Org.BouncyCastle.Crypto.Parameters
 #endif
         }
 
+        /// <summary>
+        /// Perform an X448 Diffie-Hellman agreement against <paramref name="publicKey"/> and write the
+        /// resulting <see cref="SecretSize"/>-byte shared secret into <paramref name="buf"/> starting at
+        /// <paramref name="off"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret
+        /// (degenerate peer key).</exception>
         public void GenerateSecret(X448PublicKeyParameters publicKey, byte[] buf, int off)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -100,6 +130,10 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>
+        /// Span-based overload of <see cref="GenerateSecret(X448PublicKeyParameters, byte[], int)"/>.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret.</exception>
         public void GenerateSecret(X448PublicKeyParameters publicKey, Span<byte> buf)
         {
             Span<byte> encoded = stackalloc byte[X448.PointSize];

--- a/crypto/src/crypto/parameters/X448PublicKeyParameters.cs
+++ b/crypto/src/crypto/parameters/X448PublicKeyParameters.cs
@@ -7,18 +7,29 @@ using Org.BouncyCastle.Utilities.IO;
 
 namespace Org.BouncyCastle.Crypto.Parameters
 {
+    /// <summary>
+    /// X448 public key (RFC 7748). Holds the 56-byte u-coordinate of the peer's curve point. The
+    /// encoding is stored verbatim; validation of the point is performed during scalar multiplication
+    /// in the agreement primitive.
+    /// </summary>
     public sealed class X448PublicKeyParameters
         : AsymmetricKeyParameter
     {
+        /// <summary>Length in bytes of an X448 public key encoding (56).</summary>
         public static readonly int KeySize = X448.PointSize;
 
         private readonly byte[] data = new byte[KeySize];
 
+        /// <summary>Construct from a 56-byte buffer holding the encoded u-coordinate.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X448PublicKeyParameters(byte[] buf)
             : this(Validate(buf), 0)
         {
         }
 
+        /// <summary>Construct from <paramref name="buf"/> at <paramref name="off"/>; reads
+        /// <see cref="KeySize"/> bytes.</summary>
         public X448PublicKeyParameters(byte[] buf, int off)
             : base(false)
         {
@@ -26,6 +37,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Construct from a span holding the encoded u-coordinate.</summary>
+        /// <exception cref="ArgumentException">If <paramref name="buf"/> length differs from
+        /// <see cref="KeySize"/>.</exception>
         public X448PublicKeyParameters(ReadOnlySpan<byte> buf)
             : base(false)
         {
@@ -36,6 +50,9 @@ namespace Org.BouncyCastle.Crypto.Parameters
         }
 #endif
 
+        /// <summary>Read the 56-byte encoded u-coordinate from <paramref name="input"/>.</summary>
+        /// <exception cref="EndOfStreamException">If the stream ends before <see cref="KeySize"/>
+        /// bytes have been read.</exception>
         public X448PublicKeyParameters(Stream input)
             : base(false)
         {
@@ -43,18 +60,23 @@ namespace Org.BouncyCastle.Crypto.Parameters
                 throw new EndOfStreamException("EOF encountered in middle of X448 public key");
         }
 
+        /// <summary>
+        /// Write the 56-byte encoded u-coordinate into <paramref name="buf"/> at <paramref name="off"/>.
+        /// </summary>
         public void Encode(byte[] buf, int off)
         {
             Array.Copy(data, 0, buf, off, KeySize);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Write the 56-byte encoded u-coordinate into the supplied span.</summary>
         public void Encode(Span<byte> buf)
         {
             data.CopyTo(buf);
         }
 #endif
 
+        /// <summary>Return a fresh copy of the 56-byte encoded u-coordinate.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(data);


### PR DESCRIPTION
### Description
Adds XML documentation to the public/private/key-generation parameter classes for the RFC 8032 EdDSA curves (Ed25519, Ed448) and RFC 7748 X-DH curves (X25519, X448). These are user-facing entry points for modern signing and key-agreement workflows that previously carried no API documentation.

- **Ed25519 / Ed448 public-key params** — class summary citing RFC 8032; per-constructor exception contracts (length validation, EOF on stream read, point-decode failures); `Encode`/`GetEncoded` summaries; `Verify` documenting the pure / context / prehash variant selector and the conditions each places on `ctx` and `msgLen`.
- **Ed25519 / Ed448 private-key params** — class summary noting the lazy public-key cache; constructor exceptions; `Encode`/`GetEncoded`; `GeneratePublicKey`; `Sign` mirroring the `Verify` documentation.
- **X25519 / X448 public-key params** — class summary citing RFC 7748 and noting that point validation is deferred to scalar multiplication; constructor exceptions; `Encode`/`GetEncoded`.
- **X25519 / X448 private-key params** — class summary noting clamped scalar; `GeneratePublicKey`; `GenerateSecret` documenting the `InvalidOperationException` raised on degenerate (all-zero) secrets.
- **Key-generation parameters** — class and constructor summaries citing the relevant RFC and noting the fixed strength.

### Key Accomplishments
- **Discoverability**: First-time IDE tooltips for the modern curves now identify the RFC, key/seed/scalar size, and signature size.
- **Accurate exception contracts**: `<exception>` tags only added where the method body actually throws — the EdDSA `Verify`/`Sign` algorithm-selector exceptions, X-DH agreement failure, length-validation guards, and stream-EOF guards.
- **Consistent style**: Class summaries follow the Batch 5 PQC-params pattern (RFC reference, what is wrapped, validation strategy). Span-overload entries cross-reference the byte-array overload via `<see cref=...>`.

### Verification
- **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — succeeded on `net6.0`, `netstandard2.0`, `net461` with no new warnings.
- **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).