### PR TITLE
Deprecating DerInteger ctors in favor of ValueOf

### DIFF
--- a/crypto/src/asn1/DerInteger.cs
+++ b/crypto/src/asn1/DerInteger.cs
@@ -136,14 +136,14 @@ namespace Org.BouncyCastle.Asn1
             Five = SmallConstants[5];
         }
 
-        // TODO[api] Obsolete in favour of ValueOf
+        [Obsolete("Use ValueOf instead.")]
         public DerInteger(int value)
         {
             m_contents = BigInteger.ValueOf(value).ToByteArray();
             m_start = 0;
         }
 
-        // TODO[api] Obsolete in favour of ValueOf
+        [Obsolete("Use ValueOf instead.")]
         public DerInteger(long value)
         {
             m_contents = BigInteger.ValueOf(value).ToByteArray();


### PR DESCRIPTION
## Describe your changes

Deprecating DerInteger ctors in favor of ValueOf. The task was found following the TODO list for public APIs. I found interesting as first contribution

## How has this been tested?

Warning attachment below

<img width="775" height="182" alt="image" src="https://github.com/user-attachments/assets/7fa78f61-ae45-40a2-a503-da93da7617e2" />

## Checklist before requesting a review
<!--- To check or uncheck a box, switch between "[x]" and "[ ]" below. -->

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).
