### PR TITLE
docs: add XML documentation for modern asymmetric key-pair generators (Batch 10)

### DIFF
--- a/crypto/src/crypto/generators/Ed25519KeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/Ed25519KeyPairGenerator.cs
@@ -5,16 +5,22 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for Ed25519 (RFC 8032). Only the <see cref="SecureRandom"/> from the supplied
+    /// <see cref="KeyGenerationParameters"/> is used; the 32-byte seed is drawn directly from it.
+    /// </summary>
     public class Ed25519KeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom random;
 
+        /// <summary>Capture the <see cref="SecureRandom"/> that will source the seed.</summary>
         public virtual void Init(KeyGenerationParameters parameters)
         {
             this.random = parameters.Random;
         }
 
+        /// <summary>Generate a fresh Ed25519 key pair.</summary>
         public virtual AsymmetricCipherKeyPair GenerateKeyPair()
         {
             Ed25519PrivateKeyParameters privateKey = new Ed25519PrivateKeyParameters(random);

--- a/crypto/src/crypto/generators/Ed448KeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/Ed448KeyPairGenerator.cs
@@ -5,16 +5,22 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for Ed448 (RFC 8032). Only the <see cref="SecureRandom"/> from the supplied
+    /// <see cref="KeyGenerationParameters"/> is used; the 57-byte seed is drawn directly from it.
+    /// </summary>
     public class Ed448KeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom random;
 
+        /// <summary>Capture the <see cref="SecureRandom"/> that will source the seed.</summary>
         public virtual void Init(KeyGenerationParameters parameters)
         {
             this.random = parameters.Random;
         }
 
+        /// <summary>Generate a fresh Ed448 key pair.</summary>
         public virtual AsymmetricCipherKeyPair GenerateKeyPair()
         {
             Ed448PrivateKeyParameters privateKey = new Ed448PrivateKeyParameters(random);

--- a/crypto/src/crypto/generators/MLDsaKeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/MLDsaKeyPairGenerator.cs
@@ -1,20 +1,37 @@
-﻿using Org.BouncyCastle.Crypto.Parameters;
+﻿using System;
+
+using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for ML-DSA (FIPS 204). Driven by an <see cref="MLDsaKeyGenerationParameters"/>
+    /// init payload; produces an <see cref="AsymmetricCipherKeyPair"/> bound to the chosen parameter set.
+    /// </summary>
     public sealed class MLDsaKeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom m_random;
         private MLDsaParameters m_parameters;
 
+        /// <summary>
+        /// Initialise with an <see cref="MLDsaKeyGenerationParameters"/> instance; the <see cref="SecureRandom"/>
+        /// and parameter set are taken from it.
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="MLDsaKeyGenerationParameters"/>.</exception>
         public void Init(KeyGenerationParameters parameters)
         {
             m_random = parameters.Random;
             m_parameters = ((MLDsaKeyGenerationParameters)parameters).Parameters;
         }
 
+        /// <summary>
+        /// Generate a fresh ML-DSA key pair. The private key is returned with
+        /// <see cref="MLDsaPrivateKeyParameters.Format.SeedAndEncoding"/> so the resulting key carries both
+        /// the 32-byte seed and the expanded encoding.
+        /// </summary>
         public AsymmetricCipherKeyPair GenerateKeyPair()
         {
             var engine = m_parameters.ParameterSet.GetEngine(m_random);

--- a/crypto/src/crypto/generators/MLKemKeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/MLKemKeyPairGenerator.cs
@@ -1,20 +1,37 @@
+using System;
+
 using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for ML-KEM (FIPS 203). Driven by an <see cref="MLKemKeyGenerationParameters"/>
+    /// init payload; produces an <see cref="AsymmetricCipherKeyPair"/> bound to the chosen parameter set.
+    /// </summary>
     public class MLKemKeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom m_random;
         private MLKemParameters m_parameters;
 
+        /// <summary>
+        /// Initialise with an <see cref="MLKemKeyGenerationParameters"/> instance; the <see cref="SecureRandom"/>
+        /// and parameter set are taken from it.
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="MLKemKeyGenerationParameters"/>.</exception>
         public void Init(KeyGenerationParameters parameters)
         {
             m_random = parameters.Random;
             m_parameters = ((MLKemKeyGenerationParameters)parameters).Parameters;
         }
 
+        /// <summary>
+        /// Generate a fresh ML-KEM key pair. The private key is returned with
+        /// <see cref="MLKemPrivateKeyParameters.Format.SeedAndEncoding"/> so the resulting key carries both
+        /// the 64-byte seed and the expanded encoding.
+        /// </summary>
         public AsymmetricCipherKeyPair GenerateKeyPair()
         {
             m_parameters.ParameterSet.Engine.GenerateKemKeyPair(m_random, out byte[] seed, out byte[] encoding);

--- a/crypto/src/crypto/generators/SlhDsaKeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/SlhDsaKeyPairGenerator.cs
@@ -1,21 +1,37 @@
-﻿using Org.BouncyCastle.Crypto.Parameters;
+﻿using System;
+
+using Org.BouncyCastle.Crypto.Parameters;
 using Org.BouncyCastle.Crypto.Signers.SlhDsa;
 using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for SLH-DSA (FIPS 205). Driven by an <see cref="SlhDsaKeyGenerationParameters"/>
+    /// init payload; produces an <see cref="AsymmetricCipherKeyPair"/> bound to the chosen parameter set.
+    /// </summary>
     public sealed class SlhDsaKeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom m_random;
         private SlhDsaParameters m_parameters;
 
+        /// <summary>
+        /// Initialise with an <see cref="SlhDsaKeyGenerationParameters"/> instance; the <see cref="SecureRandom"/>
+        /// and parameter set are taken from it.
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="SlhDsaKeyGenerationParameters"/>.</exception>
         public void Init(KeyGenerationParameters parameters)
         {
             m_random = parameters.Random;
             m_parameters = ((SlhDsaKeyGenerationParameters)parameters).Parameters;
         }
 
+        /// <summary>
+        /// Generate a fresh SLH-DSA key pair by drawing the three <c>n</c>-byte seeds
+        /// (<c>SK.seed</c>, <c>SK.prf</c>, <c>PK.seed</c>) and computing the hypertree root.
+        /// </summary>
         public AsymmetricCipherKeyPair GenerateKeyPair()
         {
             var engine = m_parameters.ParameterSet.GetEngine();

--- a/crypto/src/crypto/generators/X25519KeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/X25519KeyPairGenerator.cs
@@ -5,16 +5,22 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for X25519 (RFC 7748). Only the <see cref="SecureRandom"/> from the supplied
+    /// <see cref="KeyGenerationParameters"/> is used; the 32-byte clamped scalar is drawn directly from it.
+    /// </summary>
     public class X25519KeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom random;
 
+        /// <summary>Capture the <see cref="SecureRandom"/> that will source the scalar.</summary>
         public virtual void Init(KeyGenerationParameters parameters)
         {
             this.random = parameters.Random;
         }
 
+        /// <summary>Generate a fresh X25519 key pair.</summary>
         public virtual AsymmetricCipherKeyPair GenerateKeyPair()
         {
             X25519PrivateKeyParameters privateKey = new X25519PrivateKeyParameters(random);

--- a/crypto/src/crypto/generators/X448KeyPairGenerator.cs
+++ b/crypto/src/crypto/generators/X448KeyPairGenerator.cs
@@ -5,16 +5,22 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Generators
 {
+    /// <summary>
+    /// Key-pair generator for X448 (RFC 7748). Only the <see cref="SecureRandom"/> from the supplied
+    /// <see cref="KeyGenerationParameters"/> is used; the 56-byte clamped scalar is drawn directly from it.
+    /// </summary>
     public class X448KeyPairGenerator
         : IAsymmetricCipherKeyPairGenerator
     {
         private SecureRandom random;
 
+        /// <summary>Capture the <see cref="SecureRandom"/> that will source the scalar.</summary>
         public virtual void Init(KeyGenerationParameters parameters)
         {
             this.random = parameters.Random;
         }
 
+        /// <summary>Generate a fresh X448 key pair.</summary>
         public virtual AsymmetricCipherKeyPair GenerateKeyPair()
         {
             X448PrivateKeyParameters privateKey = new X448PrivateKeyParameters(random);


### PR DESCRIPTION
Adds XML documentation to the seven key-pair generators that pair with the parameter classes covered by PRs #673 (Batch 5), #677 (Batch 7), #678 (Batch 8) and #679 (Batch 9):

- **`MLKemKeyPairGenerator`** — class summary citing FIPS 203; `Init` documents the `InvalidCastException` raised when the supplied `KeyGenerationParameters` is not an `MLKemKeyGenerationParameters`; `GenerateKeyPair` notes the `SeedAndEncoding` format used for the produced private key.
- **`MLDsaKeyPairGenerator`** — same shape as ML-KEM, citing FIPS 204.
- **`SlhDsaKeyPairGenerator`** — class summary citing FIPS 205; `GenerateKeyPair` notes that the three `n`-byte seeds (`SK.seed`, `SK.prf`, `PK.seed`) are drawn from the `SecureRandom` and that the hypertree root is computed up front.
- **`Ed25519KeyPairGenerator`** / **`Ed448KeyPairGenerator`** — class summaries citing RFC 8032; `Init` / `GenerateKeyPair` documented; class summary notes the seed size (32 / 57 bytes).
- **`X25519KeyPairGenerator`** / **`X448KeyPairGenerator`** — class summaries citing RFC 7748; `Init` / `GenerateKeyPair` documented; class summary notes the clamped scalar size (32 / 56 bytes).

### Key Accomplishments
- **Closes the modern-asymmetric documentation surface**: with `KeyGenerationParameters` already documented (Batches 5/7/8/9 and #679), the matching `IAsymmetricCipherKeyPairGenerator` implementations now carry the same level of XML coverage.
- **Accurate exception contracts**: `<exception cref="InvalidCastException"/>` only added on the three PQC generators whose `Init` performs the cast; the four EdDSA/X-DH generators only capture `SecureRandom` so they don't throw.
- **Build hygiene**: added the missing `using System;` to the three PQC generator files so the new `InvalidCastException` cref resolves cleanly. No other source changes.
- **Consistent style**: Class summaries follow the same FIPS / RFC reference pattern used in Batches 5/7/8/9.
- **No overlap with open PRs**: scope is disjoint from `feature/modern-curves-docs` (Batch 7), `feature/slh-dsa-docs` (Batch 8) and `feature/ml-pqc-gaps-docs` (Batch 9). The recent `5cdc6f51 Refactor Falcon key parameter classes` upstream commit does not touch any of these files.

### Verification
- **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — succeeded on `net6.0`, `netstandard2.0`, `net461` with no new warnings (the remaining warnings are pre-existing in unrelated files).
- **Scope**: Documentation-only; the only non-doc edits are three `using System;` directives needed for the `InvalidCastException` cref.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).