### PR TITLE
docs: add XML documentation for modern asymmetric signers and X-DH agreement (Batch 11)

### DIFF
--- a/crypto/src/crypto/agreement/X25519Agreement.cs
+++ b/crypto/src/crypto/agreement/X25519Agreement.cs
@@ -4,21 +4,39 @@ using Org.BouncyCastle.Crypto.Parameters;
 
 namespace Org.BouncyCastle.Crypto.Agreement
 {
+    /// <summary>
+    /// X25519 (RFC 7748) Diffie-Hellman raw agreement. Init takes the local
+    /// <see cref="X25519PrivateKeyParameters"/>; <see cref="CalculateAgreement(ICipherParameters, byte[], int)"/>
+    /// writes the 32-byte shared secret derived against the peer's
+    /// <see cref="X25519PublicKeyParameters"/>.
+    /// </summary>
     public sealed class X25519Agreement
         : IRawAgreement
     {
         private X25519PrivateKeyParameters m_privateKey;
 
+        /// <summary>Capture the local private key used for subsequent agreements.</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="X25519PrivateKeyParameters"/>.</exception>
         public void Init(ICipherParameters parameters)
         {
             m_privateKey = (X25519PrivateKeyParameters)parameters;
         }
 
+        /// <summary>Length in bytes of the shared secret produced by the agreement (32).</summary>
         public int AgreementSize
         {
             get { return X25519PrivateKeyParameters.SecretSize; }
         }
 
+        /// <summary>
+        /// Perform the agreement against <paramref name="publicKey"/> and write the shared secret into
+        /// <paramref name="buf"/> starting at <paramref name="off"/>.
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="publicKey"/> is not an
+        /// <see cref="X25519PublicKeyParameters"/>.</exception>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret
+        /// (degenerate peer key).</exception>
         public void CalculateAgreement(ICipherParameters publicKey, byte[] buf, int off)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -29,6 +47,7 @@ namespace Org.BouncyCastle.Crypto.Agreement
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Span-based overload of <see cref="CalculateAgreement(ICipherParameters, byte[], int)"/>.</summary>
         public void CalculateAgreement(ICipherParameters publicKey, Span<byte> buf)
         {
             m_privateKey.GenerateSecret((X25519PublicKeyParameters)publicKey, buf);

--- a/crypto/src/crypto/agreement/X448Agreement.cs
+++ b/crypto/src/crypto/agreement/X448Agreement.cs
@@ -4,21 +4,39 @@ using Org.BouncyCastle.Crypto.Parameters;
 
 namespace Org.BouncyCastle.Crypto.Agreement
 {
+    /// <summary>
+    /// X448 (RFC 7748) Diffie-Hellman raw agreement. Init takes the local
+    /// <see cref="X448PrivateKeyParameters"/>; <see cref="CalculateAgreement(ICipherParameters, byte[], int)"/>
+    /// writes the 56-byte shared secret derived against the peer's
+    /// <see cref="X448PublicKeyParameters"/>.
+    /// </summary>
     public sealed class X448Agreement
         : IRawAgreement
     {
         private X448PrivateKeyParameters m_privateKey;
 
+        /// <summary>Capture the local private key used for subsequent agreements.</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="X448PrivateKeyParameters"/>.</exception>
         public void Init(ICipherParameters parameters)
         {
             m_privateKey = (X448PrivateKeyParameters)parameters;
         }
 
+        /// <summary>Length in bytes of the shared secret produced by the agreement (56).</summary>
         public int AgreementSize
         {
             get { return X448PrivateKeyParameters.SecretSize; }
         }
 
+        /// <summary>
+        /// Perform the agreement against <paramref name="publicKey"/> and write the shared secret into
+        /// <paramref name="buf"/> starting at <paramref name="off"/>.
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="publicKey"/> is not an
+        /// <see cref="X448PublicKeyParameters"/>.</exception>
+        /// <exception cref="InvalidOperationException">If the agreement produces an all-zero secret
+        /// (degenerate peer key).</exception>
         public void CalculateAgreement(ICipherParameters publicKey, byte[] buf, int off)
         {
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
@@ -29,6 +47,7 @@ namespace Org.BouncyCastle.Crypto.Agreement
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Span-based overload of <see cref="CalculateAgreement(ICipherParameters, byte[], int)"/>.</summary>
         public void CalculateAgreement(ICipherParameters publicKey, Span<byte> buf)
         {
             m_privateKey.GenerateSecret((X448PublicKeyParameters)publicKey, buf);

--- a/crypto/src/crypto/signers/Ed25519Signer.cs
+++ b/crypto/src/crypto/signers/Ed25519Signer.cs
@@ -6,6 +6,11 @@ using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// Pure Ed25519 (RFC 8032) signature primitive. Buffers the message via the streaming
+    /// <see cref="ISigner"/> surface and dispatches it to the curve routines on finalisation; no
+    /// context is permitted.
+    /// </summary>
     public class Ed25519Signer
         : ISigner
     {
@@ -15,15 +20,23 @@ namespace Org.BouncyCastle.Crypto.Signers
         private Ed25519PrivateKeyParameters privateKey;
         private Ed25519PublicKeyParameters publicKey;
 
+        /// <summary>Construct an uninitialised pure-Ed25519 signer; call <see cref="Init"/> before use.</summary>
         public Ed25519Signer()
         {
         }
 
+        /// <inheritdoc/>
         public virtual string AlgorithmName
         {
             get { return "Ed25519"; }
         }
 
+        /// <summary>
+        /// Initialise for signing (private key) or verification (public key).
+        /// </summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="Ed25519PrivateKeyParameters"/> (signing) or
+        /// <see cref="Ed25519PublicKeyParameters"/> (verification).</exception>
         public virtual void Init(bool forSigning, ICipherParameters parameters)
         {
             this.forSigning = forSigning;
@@ -42,25 +55,32 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public virtual void Update(byte b)
         {
             buffer.WriteByte(b);
         }
 
+        /// <inheritdoc/>
         public virtual void BlockUpdate(byte[] buf, int off, int len)
         {
             buffer.Write(buf, off, len);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public virtual void BlockUpdate(ReadOnlySpan<byte> input)
         {
             buffer.Write(input);
         }
 #endif
 
+        /// <summary>Length in bytes of an Ed25519 signature (64).</summary>
         public virtual int GetMaxSignatureSize() => Ed25519.SignatureSize;
 
+        /// <summary>Finalise the buffered message and produce the signature. Buffer is reset on return.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing.</exception>
         public virtual byte[] GenerateSignature()
         {
             if (!forSigning || null == privateKey)
@@ -69,6 +89,14 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.GenerateSignature(privateKey);
         }
 
+        /// <summary>
+        /// Finalise the buffered message and verify <paramref name="signature"/>. Buffer is reset on
+        /// return.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message and bound public
+        /// key; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification.</exception>
         public virtual bool VerifySignature(byte[] signature)
         {
             if (forSigning || null == publicKey)
@@ -77,6 +105,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.VerifySignature(publicKey, signature);
         }
 
+        /// <summary>Clear and rewind the buffered message.</summary>
         public virtual void Reset()
         {
             buffer.Reset();

--- a/crypto/src/crypto/signers/Ed25519ctxSigner.cs
+++ b/crypto/src/crypto/signers/Ed25519ctxSigner.cs
@@ -6,6 +6,10 @@ using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// Ed25519ctx (RFC 8032 §5.1) signature primitive: pure Ed25519 with a domain-separation context
+    /// of up to 255 bytes captured at construction.
+    /// </summary>
     public class Ed25519ctxSigner
         : ISigner
     {
@@ -16,6 +20,11 @@ namespace Org.BouncyCastle.Crypto.Signers
         private Ed25519PrivateKeyParameters privateKey;
         private Ed25519PublicKeyParameters publicKey;
 
+        /// <summary>
+        /// Construct an Ed25519ctx signer bound to the supplied <paramref name="context"/>. The context
+        /// bytes are cloned so the caller may mutate the array afterwards.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="context"/> is <c>null</c>.</exception>
         public Ed25519ctxSigner(byte[] context)
         {
             if (null == context)
@@ -24,11 +33,16 @@ namespace Org.BouncyCastle.Crypto.Signers
             this.context = (byte[])context.Clone();
         }
 
+        /// <inheritdoc/>
         public virtual string AlgorithmName
         {
             get { return "Ed25519ctx"; }
         }
 
+        /// <summary>Initialise for signing (private key) or verification (public key).</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="Ed25519PrivateKeyParameters"/> (signing) or
+        /// <see cref="Ed25519PublicKeyParameters"/> (verification).</exception>
         public virtual void Init(bool forSigning, ICipherParameters parameters)
         {
             this.forSigning = forSigning;
@@ -47,25 +61,32 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public virtual void Update(byte b)
         {
             buffer.WriteByte(b);
         }
 
+        /// <inheritdoc/>
         public virtual void BlockUpdate(byte[] buf, int off, int len)
         {
             buffer.Write(buf, off, len);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public virtual void BlockUpdate(ReadOnlySpan<byte> input)
         {
             buffer.Write(input);
         }
 #endif
 
+        /// <summary>Length in bytes of an Ed25519ctx signature (64).</summary>
         public virtual int GetMaxSignatureSize() => Ed25519.SignatureSize;
 
+        /// <summary>Finalise the buffered message and produce the signature. Buffer is reset on return.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing.</exception>
         public virtual byte[] GenerateSignature()
         {
             if (!forSigning || null == privateKey)
@@ -74,6 +95,14 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.GenerateSignature(privateKey, context);
         }
 
+        /// <summary>
+        /// Finalise the buffered message and verify <paramref name="signature"/>. Buffer is reset on
+        /// return.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message, bound public
+        /// key and captured context; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification.</exception>
         public virtual bool VerifySignature(byte[] signature)
         {
             if (forSigning || null == publicKey)
@@ -82,6 +111,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.VerifySignature(publicKey, context, signature);
         }
 
+        /// <summary>Clear and rewind the buffered message; the captured context survives.</summary>
         public virtual void Reset()
         {
             buffer.Reset();

--- a/crypto/src/crypto/signers/Ed25519phSigner.cs
+++ b/crypto/src/crypto/signers/Ed25519phSigner.cs
@@ -5,6 +5,10 @@ using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// Ed25519ph (RFC 8032 §5.1) signature primitive: pre-hashes the message with SHA-512 before
+    /// running pure Ed25519, parameterised by a fixed context captured at construction.
+    /// </summary>
     public class Ed25519phSigner
         : ISigner
     {
@@ -15,6 +19,11 @@ namespace Org.BouncyCastle.Crypto.Signers
         private Ed25519PrivateKeyParameters privateKey;
         private Ed25519PublicKeyParameters publicKey;
 
+        /// <summary>
+        /// Construct an Ed25519ph signer bound to the supplied <paramref name="context"/>. The context
+        /// bytes are cloned so the caller may mutate the array afterwards.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="context"/> is <c>null</c>.</exception>
         public Ed25519phSigner(byte[] context)
         {
             if (null == context)
@@ -23,11 +32,16 @@ namespace Org.BouncyCastle.Crypto.Signers
             this.context = (byte[])context.Clone();
         }
 
+        /// <inheritdoc/>
         public virtual string AlgorithmName
         {
             get { return "Ed25519ph"; }
         }
 
+        /// <summary>Initialise for signing (private key) or verification (public key).</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="Ed25519PrivateKeyParameters"/> (signing) or
+        /// <see cref="Ed25519PublicKeyParameters"/> (verification).</exception>
         public virtual void Init(bool forSigning, ICipherParameters parameters)
         {
             this.forSigning = forSigning;
@@ -46,25 +60,32 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public virtual void Update(byte b)
         {
             prehash.Update(b);
         }
 
+        /// <inheritdoc/>
         public virtual void BlockUpdate(byte[] buf, int off, int len)
         {
             prehash.BlockUpdate(buf, off, len);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public virtual void BlockUpdate(ReadOnlySpan<byte> input)
         {
             prehash.BlockUpdate(input);
         }
 #endif
 
+        /// <summary>Length in bytes of an Ed25519ph signature (64).</summary>
         public virtual int GetMaxSignatureSize() => Ed25519.SignatureSize;
 
+        /// <summary>Finalise the pre-hash and produce the signature.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing, or the pre-hash finalisation produces an unexpected length.</exception>
         public virtual byte[] GenerateSignature()
         {
             if (!forSigning || null == privateKey)
@@ -79,6 +100,11 @@ namespace Org.BouncyCastle.Crypto.Signers
             return signature;
         }
 
+        /// <summary>Finalise the pre-hash and verify <paramref name="signature"/>.</summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message, bound public
+        /// key and captured context; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification, or the pre-hash finalisation produces an unexpected length.</exception>
         public virtual bool VerifySignature(byte[] signature)
         {
             if (forSigning || null == publicKey)
@@ -96,6 +122,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return publicKey.Verify(Ed25519.Algorithm.Ed25519ph, context, msg, 0, Ed25519.PrehashSize, signature, 0);
         }
 
+        /// <summary>Reset the pre-hash digest; the captured context survives.</summary>
         public void Reset()
         {
             prehash.Reset();

--- a/crypto/src/crypto/signers/Ed448Signer.cs
+++ b/crypto/src/crypto/signers/Ed448Signer.cs
@@ -6,6 +6,10 @@ using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// Ed448 (RFC 8032) signature primitive: pure Ed448 with a mandatory domain-separation context of
+    /// up to 255 bytes captured at construction.
+    /// </summary>
     public class Ed448Signer
         : ISigner
     {
@@ -16,6 +20,11 @@ namespace Org.BouncyCastle.Crypto.Signers
         private Ed448PrivateKeyParameters privateKey;
         private Ed448PublicKeyParameters publicKey;
 
+        /// <summary>
+        /// Construct an Ed448 signer bound to the supplied <paramref name="context"/>. The context bytes
+        /// are cloned so the caller may mutate the array afterwards.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="context"/> is <c>null</c>.</exception>
         public Ed448Signer(byte[] context)
         {
             if (null == context)
@@ -24,11 +33,16 @@ namespace Org.BouncyCastle.Crypto.Signers
             this.context = (byte[])context.Clone();
         }
 
+        /// <inheritdoc/>
         public virtual string AlgorithmName
         {
             get { return "Ed448"; }
         }
 
+        /// <summary>Initialise for signing (private key) or verification (public key).</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="Ed448PrivateKeyParameters"/> (signing) or
+        /// <see cref="Ed448PublicKeyParameters"/> (verification).</exception>
         public virtual void Init(bool forSigning, ICipherParameters parameters)
         {
             this.forSigning = forSigning;
@@ -47,25 +61,32 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public virtual void Update(byte b)
         {
             buffer.WriteByte(b);
         }
 
+        /// <inheritdoc/>
         public virtual void BlockUpdate(byte[] buf, int off, int len)
         {
             buffer.Write(buf, off, len);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public virtual void BlockUpdate(ReadOnlySpan<byte> input)
         {
             buffer.Write(input);
         }
 #endif
 
+        /// <summary>Length in bytes of an Ed448 signature (114).</summary>
         public virtual int GetMaxSignatureSize() => Ed448.SignatureSize;
 
+        /// <summary>Finalise the buffered message and produce the signature. Buffer is reset on return.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing.</exception>
         public virtual byte[] GenerateSignature()
         {
             if (!forSigning || null == privateKey)
@@ -74,6 +95,14 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.GenerateSignature(privateKey, context);
         }
 
+        /// <summary>
+        /// Finalise the buffered message and verify <paramref name="signature"/>. Buffer is reset on
+        /// return.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message, bound public
+        /// key and captured context; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification.</exception>
         public virtual bool VerifySignature(byte[] signature)
         {
             if (forSigning || null == publicKey)
@@ -82,6 +111,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return buffer.VerifySignature(publicKey, context, signature);
         }
 
+        /// <summary>Clear and rewind the buffered message; the captured context survives.</summary>
         public virtual void Reset()
         {
             buffer.Reset();

--- a/crypto/src/crypto/signers/Ed448phSigner.cs
+++ b/crypto/src/crypto/signers/Ed448phSigner.cs
@@ -5,6 +5,10 @@ using Org.BouncyCastle.Math.EC.Rfc8032;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// Ed448ph (RFC 8032) signature primitive: pre-hashes the message with SHAKE256 before running
+    /// pure Ed448, parameterised by a fixed context captured at construction.
+    /// </summary>
     public class Ed448phSigner
         : ISigner
     {
@@ -15,6 +19,11 @@ namespace Org.BouncyCastle.Crypto.Signers
         private Ed448PrivateKeyParameters privateKey;
         private Ed448PublicKeyParameters publicKey;
 
+        /// <summary>
+        /// Construct an Ed448ph signer bound to the supplied <paramref name="context"/>. The context
+        /// bytes are cloned so the caller may mutate the array afterwards.
+        /// </summary>
+        /// <exception cref="ArgumentNullException">If <paramref name="context"/> is <c>null</c>.</exception>
         public Ed448phSigner(byte[] context)
         {
             if (null == context)
@@ -23,11 +32,16 @@ namespace Org.BouncyCastle.Crypto.Signers
             this.context = (byte[])context.Clone();
         }
 
+        /// <inheritdoc/>
         public virtual string AlgorithmName
         {
             get { return "Ed448ph"; }
         }
 
+        /// <summary>Initialise for signing (private key) or verification (public key).</summary>
+        /// <exception cref="InvalidCastException">If <paramref name="parameters"/> is not an
+        /// <see cref="Ed448PrivateKeyParameters"/> (signing) or
+        /// <see cref="Ed448PublicKeyParameters"/> (verification).</exception>
         public virtual void Init(bool forSigning, ICipherParameters parameters)
         {
             this.forSigning = forSigning;
@@ -46,25 +60,32 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public virtual void Update(byte b)
         {
             prehash.Update(b);
         }
 
+        /// <inheritdoc/>
         public virtual void BlockUpdate(byte[] buf, int off, int len)
         {
             prehash.BlockUpdate(buf, off, len);
         }
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public virtual void BlockUpdate(ReadOnlySpan<byte> input)
         {
             prehash.BlockUpdate(input);
         }
 #endif
 
+        /// <summary>Length in bytes of an Ed448ph signature (114).</summary>
         public virtual int GetMaxSignatureSize() => Ed448.SignatureSize;
 
+        /// <summary>Finalise the pre-hash and produce the signature.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing, or the pre-hash finalisation produces an unexpected length.</exception>
         public virtual byte[] GenerateSignature()
         {
             if (!forSigning || null == privateKey)
@@ -79,6 +100,11 @@ namespace Org.BouncyCastle.Crypto.Signers
             return signature;
         }
 
+        /// <summary>Finalise the pre-hash and verify <paramref name="signature"/>.</summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message, bound public
+        /// key and captured context; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification, or the pre-hash finalisation produces an unexpected length.</exception>
         public virtual bool VerifySignature(byte[] signature)
         {
             if (forSigning || null == publicKey)
@@ -96,6 +122,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return publicKey.Verify(Ed448.Algorithm.Ed448ph, context, msg, 0, Ed448.PrehashSize, signature, 0);
         }
 
+        /// <summary>Reset the pre-hash digest; the captured context survives.</summary>
         public void Reset()
         {
             prehash.Reset();

--- a/crypto/src/crypto/signers/MLDsaSigner.cs
+++ b/crypto/src/crypto/signers/MLDsaSigner.cs
@@ -7,6 +7,13 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// ML-DSA (FIPS 204) signature primitive. Accumulates the message via the streaming
+    /// <see cref="ISigner"/> surface and dispatches it through the FIPS 204 message-representative
+    /// construction. The signer must be bound to the same <see cref="MLDsaParameters.ParameterSet"/> as
+    /// the key it is initialised with. Optional <see cref="ParametersWithContext"/> (up to 255 bytes)
+    /// and <see cref="ParametersWithRandom"/> envelopes are unwrapped during <see cref="Init"/>.
+    /// </summary>
     public sealed class MLDsaSigner
         : ISigner
     {
@@ -20,6 +27,18 @@ namespace Org.BouncyCastle.Crypto.Signers
         private MLDsaPublicKeyParameters m_publicKey;
         private MLDsaEngine m_engine;
 
+        /// <summary>
+        /// Construct an ML-DSA signer for the supplied parameter set. Only the pure variants are
+        /// accepted; the HashML-DSA variants (those carrying a pre-hash OID) must go through their
+        /// dedicated wrapper instead.
+        /// </summary>
+        /// <param name="parameters">The ML-DSA parameter set; must be a pure (non-pre-hash) variant.</param>
+        /// <param name="deterministic">When <c>true</c>, signature generation uses the FIPS 204
+        /// deterministic mode (no <see cref="SecureRandom"/> draw); otherwise a fresh per-signature
+        /// nonce is sampled.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="parameters"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="parameters"/> is a HashML-DSA
+        /// variant.</exception>
         public MLDsaSigner(MLDsaParameters parameters, bool deterministic)
         {
             if (parameters == null)
@@ -31,8 +50,20 @@ namespace Org.BouncyCastle.Crypto.Signers
             m_deterministic = deterministic;
         }
 
+        /// <inheritdoc/>
         public string AlgorithmName => m_parameters.Name;
 
+        /// <summary>
+        /// Initialise for signing (private key) or verification (public key). Accepts
+        /// <see cref="ParametersWithContext"/> for a context up to 255 bytes and
+        /// <see cref="ParametersWithRandom"/> for a non-deterministic signer's nonce source.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">If the supplied context exceeds 255 bytes.</exception>
+        /// <exception cref="InvalidCastException">If the unwrapped inner parameters are not an
+        /// <see cref="MLDsaPrivateKeyParameters"/> (signing) or <see cref="MLDsaPublicKeyParameters"/>
+        /// (verification).</exception>
+        /// <exception cref="ArgumentException">If the key's parameter set differs from the one this
+        /// signer was constructed for.</exception>
         public void Init(bool forSigning, ICipherParameters parameters)
         {
             parameters = ParameterUtilities.GetContext(parameters, minLen: 0, maxLen: 255, out var providedContext);
@@ -60,16 +91,27 @@ namespace Org.BouncyCastle.Crypto.Signers
             Reset();
         }
 
+        /// <inheritdoc/>
         public void Update(byte input) => m_msgRepDigest.Update(input);
 
+        /// <inheritdoc/>
         public void BlockUpdate(byte[] input, int inOff, int inLen) => m_msgRepDigest.BlockUpdate(input, inOff, inLen);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public void BlockUpdate(ReadOnlySpan<byte> input) => m_msgRepDigest.BlockUpdate(input);
 #endif
 
+        /// <summary>Length in bytes of the signatures this signer produces (FIPS 204
+        /// <c>CryptoBytes</c>).</summary>
         public int GetMaxSignatureSize() => m_engine.CryptoBytes;
 
+        /// <summary>
+        /// Finalise the message representative and produce the signature. Internally calls
+        /// <see cref="Reset"/> on success.
+        /// </summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing.</exception>
         public byte[] GenerateSignature()
         {
             if (m_privateKey == null)
@@ -83,6 +125,14 @@ namespace Org.BouncyCastle.Crypto.Signers
             return sig;
         }
 
+        /// <summary>
+        /// Finalise the message representative and verify <paramref name="signature"/>. Internally calls
+        /// <see cref="Reset"/> on success.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message and bound public
+        /// key; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification.</exception>
         public bool VerifySignature(byte[] signature)
         {
             if (m_publicKey == null)
@@ -95,6 +145,10 @@ namespace Org.BouncyCastle.Crypto.Signers
             return result;
         }
 
+        /// <summary>
+        /// Reset the streaming digest and re-seed it with the bound public-key hash and the captured
+        /// context, ready for another sign/verify pass against the same key.
+        /// </summary>
         public void Reset()
         {
             m_msgRepDigest.Reset();

--- a/crypto/src/crypto/signers/SlhDsaSigner.cs
+++ b/crypto/src/crypto/signers/SlhDsaSigner.cs
@@ -7,6 +7,14 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Crypto.Signers
 {
+    /// <summary>
+    /// SLH-DSA (FIPS 205) signature primitive. Buffers the message via the streaming
+    /// <see cref="ISigner"/> surface prefixed with the FIPS 205 context envelope and dispatches the
+    /// whole buffer to the hypertree sign / verify routines on finalisation. The signer must be bound
+    /// to the same <see cref="SlhDsaParameters.ParameterSet"/> as the key it is initialised with.
+    /// Optional <see cref="ParametersWithContext"/> (up to 255 bytes) and
+    /// <see cref="ParametersWithRandom"/> envelopes are unwrapped during <see cref="Init"/>.
+    /// </summary>
     public sealed class SlhDsaSigner
         : ISigner
     {
@@ -19,6 +27,18 @@ namespace Org.BouncyCastle.Crypto.Signers
         private SecureRandom m_random;
         private SlhDsaEngine m_engine;
 
+        /// <summary>
+        /// Construct an SLH-DSA signer for the supplied parameter set. Only the pure variants are
+        /// accepted; the HashSLH-DSA variants (those carrying a pre-hash OID) must go through their
+        /// dedicated wrapper instead.
+        /// </summary>
+        /// <param name="parameters">The SLH-DSA parameter set; must be a pure (non-pre-hash) variant.</param>
+        /// <param name="deterministic">When <c>true</c>, signature generation omits the optional
+        /// per-signature randomiser (<c>addrnd</c>); otherwise an <c>n</c>-byte randomiser is drawn from
+        /// the bound <see cref="SecureRandom"/>.</param>
+        /// <exception cref="ArgumentNullException">If <paramref name="parameters"/> is <c>null</c>.</exception>
+        /// <exception cref="ArgumentException">If <paramref name="parameters"/> is a HashSLH-DSA
+        /// variant.</exception>
         public SlhDsaSigner(SlhDsaParameters parameters, bool deterministic)
         {
             if (parameters == null)
@@ -30,8 +50,20 @@ namespace Org.BouncyCastle.Crypto.Signers
             m_deterministic = deterministic;
         }
 
+        /// <inheritdoc/>
         public string AlgorithmName => m_parameters.Name;
 
+        /// <summary>
+        /// Initialise for signing (private key) or verification (public key). Accepts
+        /// <see cref="ParametersWithContext"/> for a context up to 255 bytes and
+        /// <see cref="ParametersWithRandom"/> for the non-deterministic signer's randomiser source.
+        /// </summary>
+        /// <exception cref="ArgumentOutOfRangeException">If the supplied context exceeds 255 bytes.</exception>
+        /// <exception cref="InvalidCastException">If the unwrapped inner parameters are not an
+        /// <see cref="SlhDsaPrivateKeyParameters"/> (signing) or <see cref="SlhDsaPublicKeyParameters"/>
+        /// (verification).</exception>
+        /// <exception cref="ArgumentException">If the key's parameter set differs from the one this
+        /// signer was constructed for.</exception>
         public void Init(bool forSigning, ICipherParameters parameters)
         {
             parameters = ParameterUtilities.GetContext(parameters, minLen: 0, maxLen: 255, out var providedContext);
@@ -58,16 +90,24 @@ namespace Org.BouncyCastle.Crypto.Signers
             m_buffer.Init(context: providedContext ?? Array.Empty<byte>());
         }
 
+        /// <inheritdoc/>
         public void Update(byte input) => m_buffer.WriteByte(input);
 
+        /// <inheritdoc/>
         public void BlockUpdate(byte[] input, int inOff, int inLen) => m_buffer.Write(input, inOff, inLen);
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public void BlockUpdate(ReadOnlySpan<byte> input) => m_buffer.Write(input);
 #endif
 
+        /// <summary>Length in bytes of the signatures this signer produces (FIPS 205
+        /// <c>SignatureLength</c>).</summary>
         public int GetMaxSignatureSize() => m_engine.SignatureLength;
 
+        /// <summary>Finalise the buffered message and produce the signature. Buffer is reset on return.</summary>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for verification,
+        /// not signing.</exception>
         public byte[] GenerateSignature()
         {
             if (m_privateKey == null)
@@ -76,6 +116,14 @@ namespace Org.BouncyCastle.Crypto.Signers
             return m_buffer.GenerateSignature(m_privateKey, m_engine, m_random);
         }
 
+        /// <summary>
+        /// Finalise the buffered message and verify <paramref name="signature"/>. Buffer is reset on
+        /// return.
+        /// </summary>
+        /// <returns><c>true</c> if the signature is valid for the accumulated message and bound public
+        /// key; otherwise <c>false</c>.</returns>
+        /// <exception cref="InvalidOperationException">If the signer was initialised for signing, not
+        /// verification.</exception>
         public bool VerifySignature(byte[] signature)
         {
             if (m_publicKey == null)
@@ -84,6 +132,7 @@ namespace Org.BouncyCastle.Crypto.Signers
             return m_buffer.VerifySignature(m_publicKey, m_engine, signature);
         }
 
+        /// <summary>Truncate the buffered message back to the captured context prefix.</summary>
         public void Reset() => m_buffer.Reset();
 
         private SlhDsaEngine GetEngine(SlhDsaParameters keyParameters)


### PR DESCRIPTION
Adds XML documentation to the nine streaming primitives that pair with the modern asymmetric parameter classes covered by PRs #673 (Batch 5), #677 (Batch 7), #678 (Batch 8), #679 (Batch 9) and the open Batch 10 generators PR. With this batch the `ISigner` / `IRawAgreement` surface for ML-DSA, SLH-DSA, EdDSA and X-DH now carries the same depth of documentation as the parameters and key-pair generators.

- **`MLDsaSigner`** — class summary citing FIPS 204; `Init` documents the `ParametersWithContext` (≤255 bytes) and `ParametersWithRandom` envelope unwrapping plus the parameter-set / key-set match check; `GenerateSignature`, `VerifySignature`, `Reset` documented with their full exception contracts.
- **`SlhDsaSigner`** — same shape as ML-DSA, citing FIPS 205; class summary explains the buffered context-prefixed message pattern.
- **`Ed25519Signer`** / **`Ed25519ctxSigner`** / **`Ed25519phSigner`** — class summaries citing RFC 8032 §5.1; `Ed25519ctxSigner` and `Ed25519phSigner` constructors document the cloned context parameter and the `ArgumentNullException` raised on a null context; the pure-Ed25519 signer explicitly notes that no context is permitted.
- **`Ed448Signer`** / **`Ed448phSigner`** — same shape as the Ed25519 ctx/ph signers, citing RFC 8032; class summaries note the SHAKE256 pre-hash for the `ph` variant.
- **`X25519Agreement`** / **`X448Agreement`** — class summaries citing RFC 7748; `Init` documents the cast contract; `CalculateAgreement` documents the `InvalidOperationException` raised when the agreement produces an all-zero secret (degenerate peer key).

### Key Accomplishments
- **Closes the modern-asymmetric documentation surface**: with `KeyGenerationParameters` (Batch 9), key-pair generators (Batch 10) and now the signer / agreement primitives documented, every user-facing class in the ML-DSA / SLH-DSA / EdDSA / X-DH stack has consistent XML coverage.
- **Accurate exception contracts**: `<exception>` tags only added where the method body actually throws — `InvalidCastException` on `Init` casts, `InvalidOperationException` on direction mismatches and pre-hash finalisation failures, `ArgumentOutOfRangeException` when the context exceeds 255 bytes for the PQC signers, `ArgumentException` on parameter-set mismatch.
- **Fixed two pre-existing CS1573 warnings**: added the missing `<param name="parameters">` tags on `MLDsaSigner` and `SlhDsaSigner` constructors that already documented `deterministic`.
- **Consistent style**: Class summaries follow the same FIPS / RFC reference pattern used in Batches 5/7/8/9/10. Internal members and pre-existing implementation comments left untouched.
- **No overlap with open PRs**: scope is disjoint from `feature/modern-curves-docs` (#677), `feature/slh-dsa-docs` (#678), `feature/ml-pqc-gaps-docs` (#679) and `feature/keypair-generators-docs` (Batch 10).

### Verification
- **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — succeeded on `net6.0`, `netstandard2.0`, `net461` with no new warnings. The two CS1573 warnings introduced by the first pass were resolved before push.
- **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).