### PR TITLE
docs: add XML documentation for PKCS#12 store API (Batch 12a-2)

### DIFF
--- a/crypto/src/pkcs/PKCS12StoreBuilder.cs
+++ b/crypto/src/pkcs/PKCS12StoreBuilder.cs
@@ -3,6 +3,10 @@ using Org.BouncyCastle.Asn1.Pkcs;
 
 namespace Org.BouncyCastle.Pkcs
 {
+    /// <summary>
+    /// Fluent builder for <see cref="Pkcs12Store"/> instances, configuring PBE algorithms and
+    /// encoding options used when saving PKCS#12 files (RFC 7292).
+    /// </summary>
     // TODO[api] Make sealed
     public class Pkcs12StoreBuilder
     {
@@ -19,16 +23,26 @@ namespace Org.BouncyCastle.Pkcs
         private bool overwriteFriendlyName = true;
         private bool enableOracleTrustedKeyUsage = true;
 
+        /// <summary>Creates a builder with library-default PBE algorithms and options.</summary>
         public Pkcs12StoreBuilder()
         {
         }
 
+        /// <summary>
+        /// Builds a new <see cref="Pkcs12Store"/> using the configured algorithms and options.
+        /// </summary>
+        /// <returns>A new, empty PKCS#12 store.</returns>
         public Pkcs12Store Build()
         {
             return new Pkcs12Store(certAlgorithm, certPrfAlgorithm, keyAlgorithm, keyPrfAlgorithm, useDerEncoding,
                 reverseCertificates, overwriteFriendlyName, enableOracleTrustedKeyUsage);
         }
 
+        /// <summary>
+        /// Sets the PBE algorithm used to encrypt certificate bags when saving (PKCS#12 scheme 1).
+        /// </summary>
+        /// <param name="certAlgorithm">The certificate encryption algorithm OID.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetCertAlgorithm(DerObjectIdentifier certAlgorithm)
         {
             this.certAlgorithm = certAlgorithm;
@@ -36,8 +50,14 @@ namespace Org.BouncyCastle.Pkcs
             return this;
         }
 
-        // Specify a PKCS#5 Scheme 2 encryption for certs
-        public Pkcs12StoreBuilder SetCertAlgorithm(DerObjectIdentifier certAlgorithm, DerObjectIdentifier certPrfAlgorithm)
+        /// <summary>
+        /// Sets the PBES2 algorithm and PRF used to encrypt certificate bags when saving (PKCS#12 scheme 2).
+        /// </summary>
+        /// <param name="certAlgorithm">The certificate encryption algorithm OID.</param>
+        /// <param name="certPrfAlgorithm">The PRF algorithm OID.</param>
+        /// <returns>This builder instance.</returns>
+        public Pkcs12StoreBuilder SetCertAlgorithm(DerObjectIdentifier certAlgorithm,
+            DerObjectIdentifier certPrfAlgorithm)
         {
             this.certAlgorithm = certAlgorithm;
             this.certPrfAlgorithm = certPrfAlgorithm;
@@ -48,14 +68,19 @@ namespace Org.BouncyCastle.Pkcs
         /// Whether to include Oracle's TrustedKeyUsage attribute in CertBag attributes. Defaults to <c>true</c>.
         /// </summary>
         /// <remarks>The OID 2.16.840.1.113894.746875.1.1 is used for this attribute.</remarks>
-        /// <param name="enableOracleTrustedKeyUsage"></param>
-        /// <returns></returns>
+        /// <param name="enableOracleTrustedKeyUsage"><c>true</c> to emit the attribute when saving.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetEnableOracleTrustedKeyUsage(bool enableOracleTrustedKeyUsage)
         {
             this.enableOracleTrustedKeyUsage = enableOracleTrustedKeyUsage;
             return this;
         }
 
+        /// <summary>
+        /// Sets the PBE algorithm used to encrypt private-key bags when saving (PKCS#12 scheme 1).
+        /// </summary>
+        /// <param name="keyAlgorithm">The key encryption algorithm OID.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetKeyAlgorithm(DerObjectIdentifier keyAlgorithm)
         {
             this.keyAlgorithm = keyAlgorithm;
@@ -63,26 +88,48 @@ namespace Org.BouncyCastle.Pkcs
             return this;
         }
 
-        // Specify a PKCS#5 Scheme 2 encryption for keys
-        public Pkcs12StoreBuilder SetKeyAlgorithm(DerObjectIdentifier keyAlgorithm, DerObjectIdentifier keyPrfAlgorithm)
+        /// <summary>
+        /// Sets the PBES2 algorithm and PRF used to encrypt private-key bags when saving (PKCS#12 scheme 2).
+        /// </summary>
+        /// <param name="keyAlgorithm">The key encryption algorithm OID.</param>
+        /// <param name="keyPrfAlgorithm">The PRF algorithm OID.</param>
+        /// <returns>This builder instance.</returns>
+        public Pkcs12StoreBuilder SetKeyAlgorithm(DerObjectIdentifier keyAlgorithm,
+            DerObjectIdentifier keyPrfAlgorithm)
         {
             this.keyAlgorithm = keyAlgorithm;
             this.keyPrfAlgorithm = keyPrfAlgorithm;
             return this;
         }
 
+        /// <summary>
+        /// Controls whether <see cref="Pkcs12Store.SetFriendlyName"/> may replace an existing friendly name.
+        /// Defaults to <c>true</c>.
+        /// </summary>
+        /// <param name="overwriteFriendlyName"><c>true</c> to allow overwriting friendly names.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetOverwriteFriendlyName(bool overwriteFriendlyName)
         {
             this.overwriteFriendlyName = overwriteFriendlyName;
             return this;
         }
 
+        /// <summary>
+        /// When <c>true</c>, certificate and key bags are written in reverse insertion order when saving.
+        /// </summary>
+        /// <param name="reverseCertificates"><c>true</c> to reverse bag order on save.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetReverseCertificates(bool reverseCertificates)
         {
             this.reverseCertificates = reverseCertificates;
             return this;
         }
 
+        /// <summary>
+        /// When <c>true</c>, saved PKCS#12 structures use DER encoding instead of BER for inner content.
+        /// </summary>
+        /// <param name="useDerEncoding"><c>true</c> for definite-length DER encoding.</param>
+        /// <returns>This builder instance.</returns>
         public Pkcs12StoreBuilder SetUseDerEncoding(bool useDerEncoding)
         {
             this.useDerEncoding = useDerEncoding;

--- a/crypto/src/pkcs/Pkcs12Entry.cs
+++ b/crypto/src/pkcs/Pkcs12Entry.cs
@@ -6,6 +6,10 @@ using Org.BouncyCastle.Utilities.Collections;
 
 namespace Org.BouncyCastle.Pkcs
 {
+    /// <summary>
+    /// Base class for PKCS#12 bag entries (private keys and certificates) carrying optional
+    /// PKCS#9 bag attributes such as friendly name and local key identifier.
+    /// </summary>
     public abstract class Pkcs12Entry
     {
         private readonly IDictionary<DerObjectIdentifier, Asn1Encodable> m_attributes;
@@ -17,17 +21,35 @@ namespace Org.BouncyCastle.Pkcs
             m_attributes = attributes;
         }
 
+        /// <summary>
+        /// Gets the bag attribute value for the given object identifier, or <c>null</c> if absent.
+        /// </summary>
+        /// <param name="oid">The bag attribute OID.</param>
         public Asn1Encodable this[DerObjectIdentifier oid] => CollectionUtilities.GetValueOrNull(m_attributes, oid);
 
+        /// <summary>Gets the object identifiers of all bag attributes on this entry.</summary>
         public IEnumerable<DerObjectIdentifier> BagAttributeKeys => CollectionUtilities.Proxy(m_attributes.Keys);
 
+        /// <summary>
+        /// Returns <c>true</c> if this entry has a PKCS#9 friendly name attribute.
+        /// </summary>
         public bool HasFriendlyName => m_attributes.ContainsKey(PkcsObjectIdentifiers.Pkcs9AtFriendlyName);
 
+        /// <summary>
+        /// Sets or replaces the PKCS#9 friendly name bag attribute on this entry.
+        /// </summary>
+        /// <param name="friendlyName">The friendly name to store.</param>
         public void SetFriendlyName(string friendlyName)
         {
             m_attributes[PkcsObjectIdentifiers.Pkcs9AtFriendlyName] = new DerBmpString(friendlyName);
         }
 
+        /// <summary>
+        /// Attempts to retrieve a bag attribute by OID.
+        /// </summary>
+        /// <param name="oid">The bag attribute OID.</param>
+        /// <param name="attribute">The attribute value, if present.</param>
+        /// <returns><c>true</c> if the attribute was found.</returns>
         public bool TryGetAttribute(DerObjectIdentifier oid, out Asn1Encodable attribute) =>
             m_attributes.TryGetValue(oid, out attribute);
     }

--- a/crypto/src/pkcs/Pkcs12Store.cs
+++ b/crypto/src/pkcs/Pkcs12Store.cs
@@ -18,8 +18,16 @@ using Org.BouncyCastle.X509.Extension;
 
 namespace Org.BouncyCastle.Pkcs
 {
+    /// <summary>
+    /// In-memory PKCS#12 keystore (PFX) as defined in RFC 7292. Loads and saves password-protected bags of
+    /// private keys and X.509 certificates. Create instances via <see cref="Pkcs12StoreBuilder"/>.
+    /// </summary>
     public class Pkcs12Store
     {
+        /// <summary>
+        /// Environment variable that, when set to <c>true</c>, suppresses the error raised when
+        /// <see cref="Load"/> is called with a password but the file does not require one.
+        /// </summary>
         public const string IgnoreUselessPasswordProperty = "Org.BouncyCastle.Pkcs12.IgnoreUselessPassword";
 
         private readonly Dictionary<string, AsymmetricKeyEntry> m_keys =
@@ -174,6 +182,21 @@ namespace Org.BouncyCastle.Pkcs
             LoadKeyBag(privateKeyInfo, bagAttributes);
         }
 
+        /// <summary>
+        /// Loads a PKCS#12 file from a stream, populating this store with keys and certificates.
+        /// </summary>
+        /// <param name="input">The stream containing the PKCS#12 PFX structure.</param>
+        /// <param name="password">
+        /// The password used to verify the MAC and decrypt shrouded key bags, or <c>null</c> if none is required.
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="input"/> is <c>null</c>, or a password is required but <paramref name="password"/> is
+        /// <c>null</c>.
+        /// </exception>
+        /// <exception cref="IOException">
+        /// The MAC verification failed, a password was supplied when none is required (unless
+        /// <see cref="IgnoreUselessPasswordProperty"/> is set), or bag attributes conflict.
+        /// </exception>
         public void Load(Stream input, char[] password)
         {
             if (input == null)
@@ -387,6 +410,11 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>
+        /// Returns the private-key entry for the given alias, or <c>null</c> if not present.
+        /// </summary>
+        /// <param name="alias">The entry alias (friendly name or local key id hex string).</param>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public AsymmetricKeyEntry GetKey(string alias)
         {
             if (alias == null)
@@ -395,6 +423,11 @@ namespace Org.BouncyCastle.Pkcs
             return CollectionUtilities.GetValueOrNull(m_keys, alias);
         }
 
+        /// <summary>
+        /// Returns <c>true</c> if the alias refers to a certificate-only entry (no private key).
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public bool IsCertificateEntry(string alias)
         {
             if (alias == null)
@@ -403,6 +436,11 @@ namespace Org.BouncyCastle.Pkcs
             return m_certs.ContainsKey(alias) && !m_keys.ContainsKey(alias);
         }
 
+        /// <summary>
+        /// Returns <c>true</c> if the alias refers to a private-key entry.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public bool IsKeyEntry(string alias)
         {
             if (alias == null)
@@ -411,6 +449,7 @@ namespace Org.BouncyCastle.Pkcs
             return m_keys.ContainsKey(alias);
         }
 
+        /// <summary>Gets all aliases in this store (union of certificate and key aliases).</summary>
         public IEnumerable<string> Aliases
         {
             get
@@ -421,6 +460,11 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>
+        /// Returns <c>true</c> if an entry exists under the given alias.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public bool ContainsAlias(string alias)
         {
             if (alias == null)
@@ -429,9 +473,13 @@ namespace Org.BouncyCastle.Pkcs
             return m_certs.ContainsKey(alias) || m_keys.ContainsKey(alias);
         }
 
-        /**
-         * simply return the cert entry for the private key
-         */
+        /// <summary>
+        /// Returns the certificate entry for the alias — either a certificate-only entry or the end-entity
+        /// certificate associated with a private-key alias.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <returns>The certificate entry, or <c>null</c> if not found.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public X509CertificateEntry GetCertificate(string alias)
         {
             if (alias == null)
@@ -449,6 +497,12 @@ namespace Org.BouncyCastle.Pkcs
             return CollectionUtilities.GetValueOrNull(m_keyCerts, keyCertsKey);
         }
 
+        /// <summary>
+        /// Finds the alias of the first entry whose certificate equals <paramref name="cert"/>.
+        /// </summary>
+        /// <param name="cert">The certificate to search for.</param>
+        /// <returns>The alias, or <c>null</c> if not found.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="cert"/> is <c>null</c>.</exception>
         public string GetCertificateAlias(X509Certificate cert)
         {
             if (cert == null)
@@ -470,6 +524,13 @@ namespace Org.BouncyCastle.Pkcs
             return null;
         }
 
+        /// <summary>
+        /// Builds the certificate chain for a private-key alias by following Authority Key Identifier
+        /// or issuer/subject matching.
+        /// </summary>
+        /// <param name="alias">The private-key alias.</param>
+        /// <returns>The chain from end entity to root, or <c>null</c> if the alias is not a key entry.</returns>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public X509CertificateEntry[] GetCertificateChain(string alias)
         {
             if (alias == null)
@@ -545,6 +606,17 @@ namespace Org.BouncyCastle.Pkcs
             return cs.ToArray();
         }
 
+        /// <summary>
+        /// Adds or replaces a certificate-only entry under the given alias.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <param name="certEntry">The certificate entry to store.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="alias"/> or <paramref name="certEntry"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// A private-key entry already exists under <paramref name="alias"/>.
+        /// </exception>
         public void SetCertificateEntry(string alias, X509CertificateEntry certEntry)
         {
             if (alias == null)
@@ -558,6 +630,14 @@ namespace Org.BouncyCastle.Pkcs
             Map(m_chainCerts, m_chainCertsOrder, new CertID(certEntry), certEntry);
         }
 
+        /// <summary>
+        /// Renames an entry by updating its PKCS#9 friendly name and re-keying internal maps.
+        /// </summary>
+        /// <param name="alias">The current alias.</param>
+        /// <param name="newFriendlyName">The new friendly name.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="alias"/> or <paramref name="newFriendlyName"/> is <c>null</c>.
+        /// </exception>
         public void SetFriendlyName(string alias, string newFriendlyName)
         {
             if (alias == null)
@@ -601,6 +681,20 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>
+        /// Adds or replaces a private-key entry and optional certificate chain under the given alias.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <param name="keyEntry">The private-key entry.</param>
+        /// <param name="chain">
+        /// The certificate chain for the key (required when <paramref name="keyEntry"/> holds a private key).
+        /// </param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="alias"/> or <paramref name="keyEntry"/> is <c>null</c>.
+        /// </exception>
+        /// <exception cref="ArgumentException">
+        /// A private key was supplied without a certificate chain.
+        /// </exception>
         public void SetKeyEntry(string alias, AsymmetricKeyEntry keyEntry, X509CertificateEntry[] chain)
         {
             if (alias == null)
@@ -630,6 +724,9 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>Removes the entry (certificate and/or key) for the given alias.</summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="alias"/> is <c>null</c>.</exception>
         public void DeleteEntry(string alias)
         {
             if (alias == null)
@@ -664,6 +761,11 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>
+        /// Returns <c>true</c> if the alias refers to an entry assignable to <paramref name="entryType"/>.
+        /// </summary>
+        /// <param name="alias">The entry alias.</param>
+        /// <param name="entryType"><see cref="X509CertificateEntry"/> or <see cref="AsymmetricKeyEntry"/>.</param>
         public bool IsEntryOfType(string alias, Type entryType)
         {
             if (entryType == typeof(X509CertificateEntry))
@@ -675,6 +777,7 @@ namespace Org.BouncyCastle.Pkcs
             return false;
         }
 
+        /// <summary>Gets the number of distinct aliases in this store.</summary>
         public int Count
         {
             get
@@ -693,6 +796,17 @@ namespace Org.BouncyCastle.Pkcs
             }
         }
 
+        /// <summary>
+        /// Writes this store as a PKCS#12 PFX structure to a stream.
+        /// </summary>
+        /// <param name="stream">The output stream.</param>
+        /// <param name="password">
+        /// The password used to encrypt shrouded key bags and the integrity MAC, or <c>null</c> for unencrypted keys.
+        /// </param>
+        /// <param name="random">Randomness source for salts and IVs.</param>
+        /// <exception cref="ArgumentNullException">
+        /// <paramref name="stream"/> or <paramref name="random"/> is <c>null</c>.
+        /// </exception>
         public void Save(Stream stream, char[] password, SecureRandom random)
         {
             if (stream == null)


### PR DESCRIPTION
### Description
Adds XML documentation to the PKCS#12 keystore API (RFC 7292) under `crypto/src/pkcs`:
- **`Pkcs12Store`** — class summary citing RFC 7292; documents `Load` and `Save` with MAC/password
  exception contracts; documents alias lookup, certificate chain, entry management (`SetCertificateEntry`,
  `SetKeyEntry`, `SetFriendlyName`, `DeleteEntry`) and the `IgnoreUselessPasswordProperty` constant.
- **`Pkcs12Entry`** — class summary for the bag-attribute base type; documents the indexer,
  `BagAttributeKeys`, `HasFriendlyName`, `SetFriendlyName`, and `TryGetAttribute`.
- **`Pkcs12StoreBuilder`** — class summary; documents `Build` and all configuration methods
  (`SetCertAlgorithm`, `SetKeyAlgorithm`, PBES2 PRF variants, `SetUseDerEncoding`,
  `SetReverseCertificates`, `SetOverwriteFriendlyName`, `SetEnableOracleTrustedKeyUsage`).
### Key Accomplishments
- **High-value user API**: PKCS#12 is a common entry point for key+certificate import/export; this PR
  documents the full public surface of the in-memory store.
- **Accurate exception contracts**: `<exception>` only where guards in the method body throw
  (`ArgumentNullException`, `ArgumentException`, `IOException` on `Load`).
- **Consistent style**: follows Batch 12a-1 / prior docs PR patterns; lines ≤120.
- **No overlap with open PRs**: disjoint from #684 (X.509 generators) and Batch 7–11.
### Verification
- **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — 0 errors, no new warnings.
- **Scope**: Documentation-only; no behavioural or signature changes.
## Checklist before requesting a review
- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [x] This change requires a documentation update
See also [Contributing Guidelines](../CONTRIBUTING.md).
