### PR TITLE
docs: add XML documentation for NTRU key parameters (Batch 13b-1)

### DIFF
--- a/crypto/src/pqc/crypto/ntru/NtruKeyGenerationParameters.cs
+++ b/crypto/src/pqc/crypto/ntru/NtruKeyGenerationParameters.cs
@@ -3,16 +3,21 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Ntru
 {
+    /// <summary>Key generation parameters for NTRU, binding a randomness source to an NTRU parameter set.</summary>
     public class NtruKeyGenerationParameters : KeyGenerationParameters
     {
         internal NtruParameters NtruParameters { get; }
 
+        /// <summary>Creates key generation parameters for the given NTRU parameter set.</summary>
+        /// <param name="random">The randomness source for key generation.</param>
+        /// <param name="ntruParameters">The NTRU parameter set to generate keys for.</param>
         // We won't be using strength as the key length differs between public & private key
         public NtruKeyGenerationParameters(SecureRandom random, NtruParameters ntruParameters) : base(random, 1)
         {
             NtruParameters = ntruParameters;
         }
 
+        /// <summary>The NTRU parameter set keys will be generated for.</summary>
         public NtruParameters GetParameters()
         {
             return NtruParameters;

--- a/crypto/src/pqc/crypto/ntru/NtruKeyParameters.cs
+++ b/crypto/src/pqc/crypto/ntru/NtruKeyParameters.cs
@@ -2,6 +2,7 @@
 
 namespace Org.BouncyCastle.Pqc.Crypto.Ntru
 {
+    /// <summary>Base class for NTRU public and private keys, carrying the associated parameter set.</summary>
     public abstract class NtruKeyParameters
         : AsymmetricKeyParameter
     {
@@ -13,8 +14,10 @@ namespace Org.BouncyCastle.Pqc.Crypto.Ntru
             m_parameters = parameters;
         }
 
+        /// <summary>The NTRU parameter set this key belongs to.</summary>
         public NtruParameters Parameters => m_parameters;
 
+        /// <summary>Returns a copy of the raw key encoding.</summary>
         public abstract byte[] GetEncoded();
     }
 }

--- a/crypto/src/pqc/crypto/ntru/NtruPublicKeyParameters.cs
+++ b/crypto/src/pqc/crypto/ntru/NtruPublicKeyParameters.cs
@@ -2,9 +2,21 @@
 
 namespace Org.BouncyCastle.Pqc.Crypto.Ntru
 {
+    /// <summary>An NTRU public (encapsulation) key, represented by its raw byte encoding.</summary>
+    /// <remarks>Instances are immutable. Create them via <see cref="FromEncoding(NtruParameters, byte[])"/>.</remarks>
     public sealed class NtruPublicKeyParameters
         : NtruKeyParameters
     {
+        /// <summary>Creates an <see cref="NtruPublicKeyParameters"/> from its raw public key encoding.</summary>
+        /// <param name="parameters">The NTRU parameter set this key belongs to.</param>
+        /// <param name="encoding">
+        /// The raw public key bytes; length must equal the parameter set's public key length.
+        /// </param>
+        /// <returns>A new instance wrapping a defensive copy of <paramref name="encoding"/>.</returns>
+        /// <exception cref="ArgumentNullException">
+        /// If <paramref name="parameters"/> or <paramref name="encoding"/> is null.
+        /// </exception>
+        /// <exception cref="ArgumentException">If <paramref name="encoding"/> has the wrong length.</exception>
         public static NtruPublicKeyParameters FromEncoding(NtruParameters parameters, byte[] encoding)
         {
 #pragma warning disable CS0618 // Type or member is obsolete
@@ -28,8 +40,10 @@ namespace Org.BouncyCastle.Pqc.Crypto.Ntru
             m_publicKey = (byte[])key.Clone();
         }
 
+        /// <summary>Returns a copy of the raw public key encoding.</summary>
         public override byte[] GetEncoded() => (byte[])m_publicKey.Clone();
 
+        /// <summary>Obsolete. Use <see cref="GetEncoded"/> instead.</summary>
         [Obsolete("Use 'GetEncoded' instead")]
         public byte[] PublicKey
         {


### PR DESCRIPTION
### Description

Adds XML documentation to the NTRU KEM parameter and key classes:

*   **`NtruKeyParameters`** — base class summary, `Parameters`, abstract `GetEncoded`.
*   **`NtruKeyGenerationParameters`** — class summary, constructor, `GetParameters`.
*   **`NtruPublicKeyParameters`** — class summary, `FromEncoding` factory (with `<param>`/`<returns>`/`<exception>`), `GetEncoded`, and the obsolete `PublicKey` property.

`NtruParameters` was already documented; this fills the remaining gaps. PQC reference style preserved — documentation only, no code changes.

### Key Accomplishments

*   **NTRU discoverability**: IDE tooltips now cover the public key/parameter surface.
*   **Accurate exception contract**: documented on `FromEncoding` where the constructor validates its arguments.
*   **Consistent style**: matches the merged ML-KEM/ML-DSA parameter docs (Batch 5/9).

### Verification

*   **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — 0 errors, no new warnings.
*   **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).