### PR TITLE
docs: add XML documentation for Classic McEliece key parameters (Batch 13b-3)

### DIFF
--- a/crypto/src/pqc/crypto/cmce/CmceKeyGenerationParameters.cs
+++ b/crypto/src/pqc/crypto/cmce/CmceKeyGenerationParameters.cs
@@ -3,17 +3,24 @@ using Org.BouncyCastle.Security;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 {
+    /// <summary>
+    /// Key generation parameters for Classic McEliece, binding a randomness source to a parameter set.
+    /// </summary>
     public sealed class CmceKeyGenerationParameters
         : KeyGenerationParameters
     {
         private CmceParameters parameters;
 
+        /// <summary>Creates key generation parameters for the given Classic McEliece parameter set.</summary>
+        /// <param name="random">The randomness source for key generation.</param>
+        /// <param name="CmceParams">The Classic McEliece parameter set to generate keys for.</param>
         public CmceKeyGenerationParameters(SecureRandom random, CmceParameters CmceParams)
             : base(random, 256)
         {
             this.parameters = CmceParams;
         }
 
+        /// <summary>The Classic McEliece parameter set keys will be generated for.</summary>
         public CmceParameters Parameters => parameters;
     }
 }

--- a/crypto/src/pqc/crypto/cmce/CmceKeyParameters.cs
+++ b/crypto/src/pqc/crypto/cmce/CmceKeyParameters.cs
@@ -2,6 +2,7 @@ using Org.BouncyCastle.Crypto;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 {
+    /// <summary>Base class for Classic McEliece public and private keys, carrying the parameter set.</summary>
     public abstract class CmceKeyParameters
         : AsymmetricKeyParameter
     {
@@ -13,6 +14,7 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
             this.parameters = parameters;
         }
 
+        /// <summary>The Classic McEliece parameter set this key belongs to.</summary>
         public CmceParameters Parameters => parameters;
     }
 }

--- a/crypto/src/pqc/crypto/cmce/CmceParameters.cs
+++ b/crypto/src/pqc/crypto/cmce/CmceParameters.cs
@@ -4,6 +4,10 @@ using Org.BouncyCastle.Crypto;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 {
+    /// <summary>
+    /// Classic McEliece code-based KEM parameter sets. The <c>f</c> variants use the semi-systematic ("fast")
+    /// matrix-reduction form, which speeds up key generation without changing the key format.
+    /// </summary>
     public sealed class CmceParameters
         : ICipherParameters
     {
@@ -13,33 +17,43 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
         private static readonly int[] poly6960 = new int[] {8, 0};
         private static readonly int[] poly8192 = new int[] {7, 2, 1, 0};
 
+        /// <summary>mceliece348864 parameter set (128-bit security).</summary>
         public static readonly CmceParameters mceliece348864r3 =
             new CmceParameters("mceliece348864", 12, 3488, 64, poly3488, false, 128);
 
+        /// <summary>mceliece348864f parameter set (128-bit security, fast key generation).</summary>
         public static readonly CmceParameters mceliece348864fr3 =
             new CmceParameters("mceliece348864f", 12, 3488, 64, poly3488, true, 128);
 
+        /// <summary>mceliece460896 parameter set (192-bit security).</summary>
         public static readonly CmceParameters mceliece460896r3 =
             new CmceParameters("mceliece460896", 13, 4608, 96, poly4608, false, 192);
 
+        /// <summary>mceliece460896f parameter set (192-bit security, fast key generation).</summary>
         public static readonly CmceParameters mceliece460896fr3 =
             new CmceParameters("mceliece460896f", 13, 4608, 96, poly4608, true, 192);
 
+        /// <summary>mceliece6688128 parameter set (256-bit security).</summary>
         public static readonly CmceParameters mceliece6688128r3 =
             new CmceParameters("mceliece6688128", 13, 6688, 128, poly6688, false, 256);
 
+        /// <summary>mceliece6688128f parameter set (256-bit security, fast key generation).</summary>
         public static readonly CmceParameters mceliece6688128fr3 =
             new CmceParameters("mceliece6688128f", 13, 6688, 128, poly6688, true, 256);
 
+        /// <summary>mceliece6960119 parameter set (256-bit security).</summary>
         public static readonly CmceParameters mceliece6960119r3 =
             new CmceParameters("mceliece6960119", 13, 6960, 119, poly6960, false, 256);
 
+        /// <summary>mceliece6960119f parameter set (256-bit security, fast key generation).</summary>
         public static readonly CmceParameters mceliece6960119fr3 =
             new CmceParameters("mceliece6960119f", 13, 6960, 119, poly6960, true, 256);
 
+        /// <summary>mceliece8192128 parameter set (256-bit security).</summary>
         public static readonly CmceParameters mceliece8192128r3 =
             new CmceParameters("mceliece8192128", 13, 8192, 128, poly8192, false, 256);
 
+        /// <summary>mceliece8192128f parameter set (256-bit security, fast key generation).</summary>
         public static readonly CmceParameters mceliece8192128fr3 =
             new CmceParameters("mceliece8192128f", 13, 8192, 128, poly8192, true, 256);
 
@@ -75,18 +89,25 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
             }
         }
 
+        /// <summary>The name of this parameter set.</summary>
         public string Name => name;
 
+        /// <summary>The field extension degree <c>m</c> (<c>GF(2^m)</c>).</summary>
         public int M => m;
 
+        /// <summary>The code length <c>n</c>.</summary>
         public int N => n;
 
+        /// <summary>The number of errors / Goppa polynomial degree <c>t</c>.</summary>
         public int T => t;
 
+        /// <summary>The semi-systematic parameter <c>mu</c> (non-zero only for the fast variants).</summary>
         public int Mu => usePivots ? 32 : 0;
 
+        /// <summary>The semi-systematic parameter <c>nu</c> (non-zero only for the fast variants).</summary>
         public int Nu => usePivots ? 64 : 0;
 
+        /// <summary>The default session key size, in bits.</summary>
         public int DefaultKeySize => defaultKeySize;
 
         internal ICmceEngine Engine => engine;

--- a/crypto/src/pqc/crypto/cmce/CmcePrivateKeyParameters.cs
+++ b/crypto/src/pqc/crypto/cmce/CmcePrivateKeyParameters.cs
@@ -4,22 +4,34 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 {
+    /// <summary>A Classic McEliece private (decapsulation) key, represented by its raw byte encoding.</summary>
     public sealed class CmcePrivateKeyParameters
         : CmceKeyParameters
     {
         internal readonly byte[] privateKey;
 
+        /// <summary>Returns a copy of the raw private key bytes.</summary>
         public byte[] GetPrivateKey()
         {
             return Arrays.Clone(privateKey);
         }
 
+        /// <summary>Creates a Classic McEliece private key from its raw encoding.</summary>
+        /// <param name="parameters">The Classic McEliece parameter set this key belongs to.</param>
+        /// <param name="privateKey">The raw private key bytes; a defensive copy is taken.</param>
         public CmcePrivateKeyParameters(CmceParameters parameters, byte[] privateKey)
             : base(true, parameters)
         {
             this.privateKey = Arrays.Clone(privateKey);
         }
 
+        /// <summary>Creates a Classic McEliece private key from its component fields.</summary>
+        /// <param name="parameters">The Classic McEliece parameter set this key belongs to.</param>
+        /// <param name="delta">The delta component.</param>
+        /// <param name="C">The C component.</param>
+        /// <param name="g">The Goppa polynomial component.</param>
+        /// <param name="alpha">The field-ordering component.</param>
+        /// <param name="s">The s component.</param>
         public CmcePrivateKeyParameters(CmceParameters parameters, byte[] delta, byte[] C, byte[] g, byte[] alpha,
             byte[] s)
             : base(true, parameters)
@@ -39,8 +51,10 @@ namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 
         }
 
+        /// <summary>Reconstructs the matching public key from this private key.</summary>
         public byte[] ReconstructPublicKey() => Parameters.Engine.GeneratePublicKeyFromPrivateKey(privateKey);
 
+        /// <summary>Returns a copy of the raw private key encoding.</summary>
         public byte[] GetEncoded()
         {
             return Arrays.Clone(privateKey);

--- a/crypto/src/pqc/crypto/cmce/CmcePublicKeyParameters.cs
+++ b/crypto/src/pqc/crypto/cmce/CmcePublicKeyParameters.cs
@@ -2,22 +2,28 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Pqc.Crypto.Cmce
 {
+    /// <summary>A Classic McEliece public (encapsulation) key, represented by its raw byte encoding.</summary>
     public sealed class CmcePublicKeyParameters
         : CmceKeyParameters
     {
         internal readonly byte[] publicKey;
 
+        /// <summary>Creates a Classic McEliece public key from its raw encoding.</summary>
+        /// <param name="parameters">The Classic McEliece parameter set this key belongs to.</param>
+        /// <param name="publicKey">The raw public key bytes; a defensive copy is taken.</param>
         public CmcePublicKeyParameters(CmceParameters parameters, byte[] publicKey)
             : base(false, parameters)
         {
             this.publicKey = Arrays.Clone(publicKey);
         }
 
+        /// <summary>Returns a copy of the raw public key bytes.</summary>
         public byte[] GetPublicKey()
-        { 
+        {
             return Arrays.Clone(publicKey);
         }
 
+        /// <summary>Returns a copy of the raw public key encoding.</summary>
         public byte[] GetEncoded()
         {
             return GetPublicKey();


### PR DESCRIPTION
### Description

Adds XML documentation to the Classic McEliece KEM parameter and key classes (all previously undocumented):

*   **`CmceParameters`** — class summary (including what the `f` "fast" variants mean), all ten `mceliece*` instances, and the public properties (`Name`, `M`, `N`, `T`, `Mu`, `Nu`, `DefaultKeySize`).
*   **`CmceKeyParameters`** — base class summary, `Parameters`.
*   **`CmceKeyGenerationParameters`** — class summary, constructor, `Parameters`.
*   **`CmcePublicKeyParameters`** — class summary, constructor, `GetPublicKey`, `GetEncoded`.
*   **`CmcePrivateKeyParameters`** — class summary, both constructors (raw and component-field), `GetPrivateKey`, `ReconstructPublicKey`, `GetEncoded`.

PQC reference style preserved — documentation only, no code changes.

### Key Accomplishments

*   **Classic McEliece discoverability**: IDE tooltips now cover the full public parameter/key surface (0 → docs across 5 files), including the `r3` vs `f` variant distinction.
*   **Consistent style**: matches the merged ML-KEM/ML-DSA parameter docs (Batch 5/9).

### Verification

*   **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — 0 errors, no new warnings.
*   **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).