### PR TITLE
docs: add XML documentation for CMS EnvelopedData (Batch 15a)

### DIFF
--- a/crypto/src/cms/CMSEnvelopedData.cs
+++ b/crypto/src/cms/CMSEnvelopedData.cs
@@ -7,9 +7,11 @@ using Org.BouncyCastle.Asn1.X509;
 
 namespace Org.BouncyCastle.Cms
 {
-    /**
-     * containing class for an CMS Enveloped Data object
-     */
+    /// <summary>
+    /// Represents a CMS EnvelopedData message. Parse an encoded message, obtain recipients from
+    /// <see cref="GetRecipientInfos"/>, match one with <see cref="RecipientID"/>, then decrypt via
+    /// <see cref="RecipientInformation"/>.
+    /// </summary>
     public class CmsEnvelopedData
     {
         private readonly ContentInfo m_contentInfo;
@@ -17,16 +19,23 @@ namespace Org.BouncyCastle.Cms
         private readonly OriginatorInformation m_originatorInformation;
         private readonly RecipientInformationStore m_recipientInfoStore;
 
+        /// <summary>Creates an instance from an encoded EnvelopedData message.</summary>
+        /// <param name="envelopedData">The DER-encoded CMS ContentInfo bytes.</param>
         public CmsEnvelopedData(byte[] envelopedData)
             : this(CmsUtilities.ReadContentInfo(envelopedData))
         {
         }
 
+        /// <summary>Creates an instance from an encoded EnvelopedData message.</summary>
+        /// <param name="envelopedData">A stream containing the DER-encoded CMS ContentInfo.</param>
         public CmsEnvelopedData(Stream envelopedData)
             : this(CmsUtilities.ReadContentInfo(envelopedData))
         {
         }
 
+        /// <summary>Creates an instance from a parsed CMS ContentInfo structure.</summary>
+        /// <param name="contentInfo">The CMS ContentInfo wrapping an EnvelopedData object.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="contentInfo"/> is null.</exception>
         public CmsEnvelopedData(ContentInfo contentInfo)
         {
             m_contentInfo = contentInfo ?? throw new ArgumentNullException(nameof(contentInfo));
@@ -55,35 +64,30 @@ namespace Org.BouncyCastle.Cms
             m_recipientInfoStore = CmsEnvelopedHelper.BuildRecipientInformationStore(recipientInfos, secureReadable);
         }
 
+        /// <summary>Gets originator certificates and CRLs carried in the message, or null if absent.</summary>
         public OriginatorInformation OriginatorInformation => m_originatorInformation;
 
+        /// <summary>Gets the content-encryption algorithm identifier.</summary>
         public AlgorithmIdentifier EncryptionAlgorithmID =>
             EnvelopedData.EncryptedContentInfo.ContentEncryptionAlgorithm;
 
-        /**
-         * return the object identifier for the content encryption algorithm.
-         */
+        /// <summary>Return the object identifier for the content-encryption algorithm.</summary>
         // TODO[api] Return the OID itself
         public string EncryptionAlgOid => EncryptionAlgorithmID.Algorithm.GetID();
 
-        /**
-         * return a store of the intended recipients for this message
-         */
+        /// <summary>Returns a store of the intended recipients for this message.</summary>
         public RecipientInformationStore GetRecipientInfos() => m_recipientInfoStore;
 
+        /// <summary>Gets the CMS ContentInfo wrapper for this message.</summary>
         public ContentInfo ContentInfo => m_contentInfo;
 
+        /// <summary>Gets the underlying ASN.1 EnvelopedData structure.</summary>
         public EnvelopedData EnvelopedData => m_envelopedData;
 
-        /**
-         * return a table of the unprotected attributes indexed by
-         * the OID of the attribute.
-         */
+        /// <summary>Returns a table of unprotected attributes indexed by attribute OID, or null if absent.</summary>
         public Asn1.Cms.AttributeTable GetUnprotectedAttributes() => EnvelopedData.UnprotectedAttrs?.ToAttributeTable();
 
-        /**
-         * return the ASN.1 encoded representation of this object.
-         */
+        /// <summary>Returns the DER encoding of this message.</summary>
         public byte[] GetEncoded() => m_contentInfo.GetEncoded();
     }
 }


### PR DESCRIPTION
### Description

Adds XML documentation to `CmsEnvelopedData` — the read-side entry point for CMS EnvelopedData
(PKCS#7 enveloped-data) messages:

* **Class summary** — describes the decrypt workflow: parse the message, obtain recipients, match a
  `RecipientID`, then decrypt via `RecipientInformation` (Batch 14a).
* **Constructors** — byte array, stream, and `ContentInfo` overloads; `ArgumentNullException` on
  the core constructor where the code validates its argument.
* **Properties and accessors** — originator information, content-encryption algorithm, recipient store,
  `ContentInfo` / `EnvelopedData` structures, unprotected attributes, and DER encoding.

Legacy `/**` block comments converted to XML.

### Key Accomplishments

* **Enveloped-data discoverability**: IDE tooltips now cover the full public read-side surface used
  after creating messages with `CmsEnvelopedDataGenerator`.
* **Accurate exception contracts**: `ArgumentNullException` documented only on the constructor that
  validates `contentInfo`.
* **Focused scope**: single file; no behavioural or signature changes.
* **Documentation quality**: all new or modified XML documentation lines are at most 120 characters.

### Verification

* **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` — 0 errors.
* **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).