### PR TITLE
docs: add XML documentation for CMS exceptions and PBE keys (Batch 16e)

### DIFF
--- a/crypto/src/cms/CMSAttributeTableGenerationException.cs
+++ b/crypto/src/cms/CMSAttributeTableGenerationException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>Exception thrown when a CMS signed or authenticated attribute table cannot be generated.</summary>
     [Serializable]
     public class CmsAttributeTableGenerationException
         : CmsException

--- a/crypto/src/cms/CMSException.cs
+++ b/crypto/src/cms/CMSException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>General exception thrown when CMS processing fails.</summary>
     [Serializable]
     public class CmsException
         : Exception

--- a/crypto/src/cms/CMSPBEKey.cs
+++ b/crypto/src/cms/CMSPBEKey.cs
@@ -11,6 +11,10 @@ using Org.BouncyCastle.Utilities;
 
 namespace Org.BouncyCastle.Cms
 {
+	/// <summary>
+	/// Base class for password-based keys used with CMS enveloped-data recipients. Passed to
+	/// <see cref="CmsEnvelopedGenerator.AddPasswordRecipient"/>.
+	/// </summary>
 	public abstract class CmsPbeKey
 		// TODO Create an equivalent interface somewhere?
 		//	: PBEKey
@@ -20,6 +24,10 @@ namespace Org.BouncyCastle.Cms
 		internal readonly byte[]	salt;
 		internal readonly int		iterationCount;
 
+		/// <summary>Creates a PBE key from explicit password, salt, and iteration count.</summary>
+		/// <param name="password">The password characters.</param>
+		/// <param name="salt">The PBKDF2 salt.</param>
+		/// <param name="iterationCount">The PBKDF2 iteration count.</param>
 		public CmsPbeKey(
 			char[]	password,
 			byte[]	salt,
@@ -30,6 +38,10 @@ namespace Org.BouncyCastle.Cms
 			this.iterationCount = iterationCount;
 		}
 
+		/// <summary>Creates a PBE key from a password and PBKDF2 AlgorithmIdentifier.</summary>
+		/// <param name="password">The password characters.</param>
+		/// <param name="keyDerivationAlgorithm">The PBKDF2 algorithm identifier.</param>
+		/// <exception cref="ArgumentException">The key derivation algorithm is not PBKDF2.</exception>
 		public CmsPbeKey(
 			char[]				password,
 			AlgorithmIdentifier keyDerivationAlgorithm)
@@ -49,6 +61,7 @@ namespace Org.BouncyCastle.Cms
 		}
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <summary>Creates a PBE key from explicit password, salt, and iteration count.</summary>
         public CmsPbeKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> salt, int iterationCount)
         {
 			this.password = password.ToArray();
@@ -56,6 +69,8 @@ namespace Org.BouncyCastle.Cms
             this.iterationCount = iterationCount;
         }
 
+        /// <summary>Creates a PBE key from a password and PBKDF2 AlgorithmIdentifier.</summary>
+        /// <exception cref="ArgumentException">The key derivation algorithm is not PBKDF2.</exception>
         public CmsPbeKey(ReadOnlySpan<char> password, AlgorithmIdentifier keyDerivationAlgorithm)
         {
             if (!keyDerivationAlgorithm.Algorithm.Equals(PkcsObjectIdentifiers.IdPbkdf2))
@@ -79,26 +94,32 @@ namespace Org.BouncyCastle.Cms
 			Arrays.ZeroMemory(this.password);
 		}
 
+		/// <summary>Gets a copy of the PBKDF2 salt.</summary>
 		public byte[] Salt
 		{
 			get { return Arrays.Clone(salt); }
 		}
 
+		/// <summary>Gets the PBKDF2 iteration count.</summary>
 		public int IterationCount
 		{
 			get { return iterationCount; }
 		}
 
+		/// <summary>Gets the key algorithm name (<c>PKCS5S2</c>).</summary>
 		public string Algorithm
 		{
 			get { return "PKCS5S2"; }
 		}
 
+		/// <summary>Gets the encoding format name (<c>RAW</c>).</summary>
 		public string Format
 		{
 			get { return "RAW"; }
 		}
 
+		/// <summary>Returns null; raw encoding is not supported.</summary>
+		/// <returns>Always null.</returns>
 		public byte[] GetEncoded()
 		{
 			return null;

--- a/crypto/src/cms/CMSStreamException.cs
+++ b/crypto/src/cms/CMSStreamException.cs
@@ -4,6 +4,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>Exception thrown when CMS streaming operations fail.</summary>
     [Serializable]
     public class CmsStreamException
         : IOException

--- a/crypto/src/cms/CmsAlgorithmNotAllowedException.cs
+++ b/crypto/src/cms/CmsAlgorithmNotAllowedException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>Exception thrown when a CMS operation does not permit the requested algorithm.</summary>
     [Serializable]
     public class CmsAlgorithmNotAllowedException
         : CmsException

--- a/crypto/src/cms/CmsTagLengthException.cs
+++ b/crypto/src/cms/CmsTagLengthException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>Exception thrown when an authenticated CMS content tag length is invalid.</summary>
     [Serializable]
     public class CmsTagLengthException
         : CmsException

--- a/crypto/src/cms/CmsVerifierCertificateNotValidException.cs
+++ b/crypto/src/cms/CmsVerifierCertificateNotValidException.cs
@@ -3,6 +3,7 @@ using System.Runtime.Serialization;
 
 namespace Org.BouncyCastle.Cms
 {
+    /// <summary>Exception thrown when a signer certificate is not valid at the signing time.</summary>
     [Serializable]
     public class CmsVerifierCertificateNotValidException
         : CmsException

--- a/crypto/src/cms/PKCS5Scheme2PBEKey.cs
+++ b/crypto/src/cms/PKCS5Scheme2PBEKey.cs
@@ -8,12 +8,11 @@ using Org.BouncyCastle.Crypto.Parameters;
 
 namespace Org.BouncyCastle.Cms
 {
-	/// <summary>
-	/// PKCS5 scheme-2 - password converted to bytes assuming ASCII.
-	/// </summary>
+	/// <summary>PKCS#5 scheme 2 PBE key with the password encoded as ASCII bytes.</summary>
 	public class Pkcs5Scheme2PbeKey
 		: CmsPbeKey
 	{
+		/// <inheritdoc/>
 		public Pkcs5Scheme2PbeKey(
 			char[]	password,
 			byte[]	salt,
@@ -22,6 +21,7 @@ namespace Org.BouncyCastle.Cms
 		{
 		}
 
+		/// <inheritdoc/>
 		public Pkcs5Scheme2PbeKey(
 			char[]				password,
 			AlgorithmIdentifier keyDerivationAlgorithm)
@@ -30,11 +30,13 @@ namespace Org.BouncyCastle.Cms
 		}
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public Pkcs5Scheme2PbeKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> salt, int iterationCount)
             : base(password, salt, iterationCount)
         {
         }
 
+        /// <inheritdoc/>
         public Pkcs5Scheme2PbeKey(ReadOnlySpan<char> password, AlgorithmIdentifier keyDerivationAlgorithm)
             : base(password, keyDerivationAlgorithm)
         {

--- a/crypto/src/cms/PKCS5Scheme2UTF8PBEKey.cs
+++ b/crypto/src/cms/PKCS5Scheme2UTF8PBEKey.cs
@@ -8,12 +8,11 @@ using Org.BouncyCastle.Crypto.Parameters;
 
 namespace Org.BouncyCastle.Cms
 {
-	/**
-	 * PKCS5 scheme-2 - password converted to bytes using UTF-8.
-	 */
+	/// <summary>PKCS#5 scheme 2 PBE key with the password encoded as UTF-8 bytes.</summary>
 	public class Pkcs5Scheme2Utf8PbeKey
 		: CmsPbeKey
 	{
+		/// <inheritdoc/>
 		public Pkcs5Scheme2Utf8PbeKey(
 			char[]	password,
 			byte[]	salt,
@@ -22,6 +21,7 @@ namespace Org.BouncyCastle.Cms
 		{
 		}
 
+		/// <inheritdoc/>
 		public Pkcs5Scheme2Utf8PbeKey(
 			char[]				password,
 			AlgorithmIdentifier keyDerivationAlgorithm)
@@ -30,11 +30,13 @@ namespace Org.BouncyCastle.Cms
 		}
 
 #if NETCOREAPP2_1_OR_GREATER || NETSTANDARD2_1_OR_GREATER
+        /// <inheritdoc/>
         public Pkcs5Scheme2Utf8PbeKey(ReadOnlySpan<char> password, ReadOnlySpan<byte> salt, int iterationCount)
             : base(password, salt, iterationCount)
         {
         }
 
+        /// <inheritdoc/>
         public Pkcs5Scheme2Utf8PbeKey(ReadOnlySpan<char> password, AlgorithmIdentifier keyDerivationAlgorithm)
             : base(password, keyDerivationAlgorithm)
         {


### PR DESCRIPTION
### Description

Adds XML documentation to CMS exception types and password-based key classes used with enveloped-data
recipients:

* **`CmsException`** and derived types - class summaries for `CmsAttributeTableGenerationException`,
  `CmsStreamException`, `CmsAlgorithmNotAllowedException`, `CmsTagLengthException`, and
  `CmsVerifierCertificateNotValidException`.
* **`CmsPbeKey`** - base class summary, constructors, properties, and `GetEncoded`; links to
  `CmsEnvelopedGenerator.AddPasswordRecipient`.
* **`Pkcs5Scheme2Utf8PbeKey`** / **`Pkcs5Scheme2PbeKey`** - UTF-8 vs ASCII password encoding; public
  constructors documented with `<inheritdoc/>`.

Legacy `/**` block comments converted to XML where present.

### Key Accomplishments

* **CMS error discoverability**: IDE tooltips now identify CMS-specific exception types.
* **PBE recipient clarity**: documents password-based key material used with `AddPasswordRecipient`.
* **Accurate exception contracts**: `<exception>` only on `CmsPbeKey` constructors where PBKDF2 is validated.
* **Focused bundle**: nine related CMS support files; no behavioural or signature changes.
* **Documentation quality**: all new or modified `///` lines are at most 120 characters.

### Verification

* **Build Status**: `dotnet build crypto/src/BouncyCastle.Crypto.csproj -c Release` - 0 errors, no new warnings.
* **Scope**: Documentation-only; no behavioural or signature changes.

## Checklist before requesting a review

- [x] I have performed a self-review of my code
- [x] I have kept the patch limited to only change the parts related to the patch
- [ ] This change requires a documentation update

See also [Contributing Guidelines](../CONTRIBUTING.md).